### PR TITLE
Implementation of list minimal adjustment sets (identification)

### DIFF
--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -91,7 +91,7 @@ class CausalDAG(nx.DiGraph):
         """
         Given a list of treament variables and a list of outcome variables, transform a CausalDAG into an ancestor
         graph. An ancestor graph G[An(W)] for a CausalDAG G is a subgraph of G consisting of only the vertices who are
-        ancestors of the set of variables W and all edges between them. Note that a node is ancestor of itself.
+        ancestors of the set of variables W and all edges between them. Note that a node is an ancestor of itself.
 
         Reference: (Adjustment Criteria in Causal Diagrams: An Algorithmic Perspective, Textor and Lískiewicz, 2012,
         p. 3 [Descendants and Ancestors]).

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -106,6 +106,9 @@ class CausalDAG(nx.DiGraph):
         possible adjustment set. Z is the minimal adjustment set if no element of Z can be removed without breaking the
         constructive back-door criterion.
 
+        Reference: Separators and adjustment sets in causal graphs: Complete criteria and an algorithmic framework,
+        Zander et al., 2019, Corollary 5, p.19)
+
         :param treatments: List of treatment variables.
         :param outcomes: List of outcome variables.
         :param adjustment_set: Set of adjustment variables.

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -10,8 +10,7 @@ logger = logging.getLogger(__name__)
 
 def list_all_min_sep(graph: nx.Graph, treatment_node: Node, outcome_node: Node, treatment_node_set: {Node},
                      outcome_node_set: {Node}):
-    """
-    A backtracking algorithm for listing all minimal treatment-outcome separators in an undirected graph.
+    """ A backtracking algorithm for listing all minimal treatment-outcome separators in an undirected graph.
 
     Reference: (Space-optimal, backtracking algorithms to list the minimal vertex separators of a graph, Ken Takata,
     2013, p.5, ListMinSep procedure).
@@ -68,8 +67,7 @@ def list_all_min_sep(graph: nx.Graph, treatment_node: Node, outcome_node: Node, 
 
 
 def close_separator(graph: nx.Graph, treatment_node: Node, outcome_node: Node, treatment_node_set: {Node}) -> {Node}:
-    """
-    Compute the close separator for a set of treatments in an undirected graph.
+    """ Compute the close separator for a set of treatments in an undirected graph.
 
     A close separator (relative to a set of variables X) is a separator whose vertices are adjacent to those in X.
     An X-Y separator is a set of variables which, once deleted from a graph, create a subgraph in which X and Y
@@ -99,8 +97,7 @@ def close_separator(graph: nx.Graph, treatment_node: Node, outcome_node: Node, t
 
 
 class CausalDAG(nx.DiGraph):
-    """
-    A causal DAG is a directed acyclic graph in which nodes represent random variables and edges represent causality
+    """ A causal DAG is a directed acyclic graph in which nodes represent random variables and edges represent causality
     between a pair of random variables. We implement a CausalDAG as a networkx DiGraph with an additional check that
     ensures it is acyclic. A CausalDAG must be specified as a dot file.
     """
@@ -116,8 +113,7 @@ class CausalDAG(nx.DiGraph):
             raise nx.HasACycle("Invalid Causal DAG: contains a cycle.")
 
     def add_edge(self, u_of_edge: Node, v_of_edge: Node, **attr):
-        """
-        Add an edge to the causal DAG. Overrides the default networkx method to prevent users from adding a cycle.
+        """ Add an edge to the causal DAG. Overrides the default networkx method to prevent users from adding a cycle.
         :param u_of_edge: From node
         :param v_of_edge: To node
         :param attr: Attributes
@@ -134,8 +130,7 @@ class CausalDAG(nx.DiGraph):
         return not list(nx.simple_cycles(self.graph))
 
     def get_proper_backdoor_graph(self, treatments: [str], outcomes: [str]) -> 'CausalDAG':
-        """
-        Convert the causal DAG to a proper back-door graph. A proper back-door graph of a causal DAG is obtained by
+        """ Convert the causal DAG to a proper back-door graph. A proper back-door graph of a causal DAG is obtained by
         removing the first edge of every proper causal path from treatments to outcomes. A proper causal path from
         X to Y is a path of directed edges that starts from X and ends in Y.
 
@@ -158,8 +153,7 @@ class CausalDAG(nx.DiGraph):
         return proper_backdoor_graph
 
     def get_ancestor_graph(self, treatments: [str], outcomes: [str]) -> 'CausalDAG':
-        """
-        Given a list of treament variables and a list of outcome variables, transform a CausalDAG into an ancestor
+        """ Given a list of treament variables and a list of outcome variables, transform a CausalDAG into an ancestor
         graph. An ancestor graph G[An(W)] for a CausalDAG G is a subgraph of G consisting of only the vertices who are
         ancestors of the set of variables W and all edges between them. Note that a node is an ancestor of itself.
 
@@ -181,8 +175,7 @@ class CausalDAG(nx.DiGraph):
         return ancestor_graph
 
     def enumerate_minimal_adjustment_sets(self, treatments: [str], outcomes: [str]) -> [{str}]:
-        """
-        Get the smallest possible set of variables that blocks all back-door paths between all pairs of treatments
+        """ Get the smallest possible set of variables that blocks all back-door paths between all pairs of treatments
         and outcomes. This is an implementation of the Algorithm presented in Adjustment Criteria in Causal Diagrams: An
         Algorithmic Perspective, Textor and Lískiewicz, 2012 and extended in Separators and adjustment sets in causal
         graphs: Complete criteria and an algorithmic framework, Zander et al.,  2019. These works use the algorithm
@@ -226,10 +219,9 @@ class CausalDAG(nx.DiGraph):
         return minimum_adjustment_sets
 
     def adjustment_set_is_minimal(self, treatments: [str], outcomes: [str], adjustment_set: {str}) -> bool:
-        """
-        Given a list of treatments X, a list of outcomes Y, and an adjustment set Z, determine whether Z is the smallest
-        possible adjustment set. Z is the minimal adjustment set if no element of Z can be removed without breaking the
-        constructive back-door criterion.
+        """ Given a list of treatments X, a list of outcomes Y, and an adjustment set Z, determine whether Z is the
+        smallest possible adjustment set. Z is the minimal adjustment set if no element of Z can be removed without
+        breaking the constructive back-door criterion.
 
         Reference: Separators and adjustment sets in causal graphs: Complete criteria and an algorithmic framework,
         Zander et al., 2019, Corollary 5, p.19)
@@ -261,8 +253,7 @@ class CausalDAG(nx.DiGraph):
 
     def constructive_backdoor_criterion(self, proper_backdoor_graph: 'CausalDAG', treatments: [str], outcomes: [str],
                                         covariates: [str]) -> bool:
-        """
-        A variation of Pearl's back-door criterion applied to a proper_backdoor_graph which enables more efficient
+        """ A variation of Pearl's back-door criterion applied to a proper_backdoor_graph which enables more efficient
         computation of minimal adjustment sets for the effect of a set of treatments on a set of outcomes.
 
         The constructive back-door criterion is satisfied for a causal DAG G, a set of treatments X, a set of outcomes
@@ -301,8 +292,7 @@ class CausalDAG(nx.DiGraph):
         return True
 
     def proper_causal_pathway(self, treatments: [str], outcomes: [str]) -> [str]:
-        """
-        Given a list of treatments and outcomes, compute the proper causal pathways between them.
+        """ Given a list of treatments and outcomes, compute the proper causal pathways between them.
         PCP(X, Y) = {DeX^(X) - X} intersect AnX_(Y)}, where:
         - DeX^(X) refers to the descendents of X in the graph obtained by deleting all edges into X.
         - AnX_(Y) refers to the ancestors of Y in the graph obtained by deleting all edges leaving X.
@@ -321,9 +311,8 @@ class CausalDAG(nx.DiGraph):
         return nodes_on_proper_causal_paths
 
     def get_backdoor_graph(self, treatments: [str]) -> 'CausalDAG':
-        """
-        A back-door graph is a graph for the list of treatments is a Causal DAG in which all edges leaving the treatment
-        nodes are deleted.
+        """ A back-door graph is a graph for the list of treatments is a Causal DAG in which all edges leaving the
+        treatment nodes are deleted.
 
         :param treatments: The set of treatments whose outgoing edges will be deleted.
         :return: A back-door graph corresponding to the given causal DAG and set of treatments.

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -97,6 +97,7 @@ def close_separator(graph: nx.Graph, treatment_node: Node, outcome_node: Node, t
 
 
 class CausalDAG(nx.DiGraph):
+
     """ A causal DAG is a directed acyclic graph in which nodes represent random variables and edges represent causality
     between a pair of random variables. We implement a CausalDAG as a networkx DiGraph with an additional check that
     ensures it is acyclic. A CausalDAG must be specified as a dot file.
@@ -113,7 +114,9 @@ class CausalDAG(nx.DiGraph):
             raise nx.HasACycle("Invalid Causal DAG: contains a cycle.")
 
     def add_edge(self, u_of_edge: Node, v_of_edge: Node, **attr):
-        """ Add an edge to the causal DAG. Overrides the default networkx method to prevent users from adding a cycle.
+        """ Add an edge to the causal DAG.
+
+        Overrides the default networkx method to prevent users from adding a cycle.
         :param u_of_edge: From node
         :param v_of_edge: To node
         :param attr: Attributes
@@ -123,14 +126,16 @@ class CausalDAG(nx.DiGraph):
             raise nx.HasACycle("Invalid Causal DAG: contains a cycle.")
 
     def is_acyclic(self) -> bool:
-        """
-        Checks if the graph is acyclic.
+        """Checks if the graph is acyclic.
+
         :return: True if acyclic, False otherwise.
         """
         return not list(nx.simple_cycles(self.graph))
 
     def get_proper_backdoor_graph(self, treatments: [str], outcomes: [str]) -> 'CausalDAG':
-        """ Convert the causal DAG to a proper back-door graph. A proper back-door graph of a causal DAG is obtained by
+        """ Convert the causal DAG to a proper back-door graph.
+
+        A proper back-door graph of a causal DAG is obtained by
         removing the first edge of every proper causal path from treatments to outcomes. A proper causal path from
         X to Y is a path of directed edges that starts from X and ends in Y.
 
@@ -154,7 +159,9 @@ class CausalDAG(nx.DiGraph):
 
     def get_ancestor_graph(self, treatments: [str], outcomes: [str]) -> 'CausalDAG':
         """ Given a list of treament variables and a list of outcome variables, transform a CausalDAG into an ancestor
-        graph. An ancestor graph G[An(W)] for a CausalDAG G is a subgraph of G consisting of only the vertices who are
+        graph.
+
+        An ancestor graph G[An(W)] for a CausalDAG G is a subgraph of G consisting of only the vertices who are
         ancestors of the set of variables W and all edges between them. Note that a node is an ancestor of itself.
 
         Reference: (Adjustment Criteria in Causal Diagrams: An Algorithmic Perspective, Textor and Lískiewicz, 2012,
@@ -176,7 +183,9 @@ class CausalDAG(nx.DiGraph):
 
     def enumerate_minimal_adjustment_sets(self, treatments: [str], outcomes: [str]) -> [{str}]:
         """ Get the smallest possible set of variables that blocks all back-door paths between all pairs of treatments
-        and outcomes. This is an implementation of the Algorithm presented in Adjustment Criteria in Causal Diagrams: An
+        and outcomes.
+
+        This is an implementation of the Algorithm presented in Adjustment Criteria in Causal Diagrams: An
         Algorithmic Perspective, Textor and Lískiewicz, 2012 and extended in Separators and adjustment sets in causal
         graphs: Complete criteria and an algorithmic framework, Zander et al.,  2019. These works use the algorithm
         presented by Takata et al. in their work entitled: Space-optimal, backtracking algorithms to list the minimal
@@ -220,8 +229,10 @@ class CausalDAG(nx.DiGraph):
 
     def adjustment_set_is_minimal(self, treatments: [str], outcomes: [str], adjustment_set: {str}) -> bool:
         """ Given a list of treatments X, a list of outcomes Y, and an adjustment set Z, determine whether Z is the
-        smallest possible adjustment set. Z is the minimal adjustment set if no element of Z can be removed without
-        breaking the constructive back-door criterion.
+        smallest possible adjustment set.
+
+        Z is the minimal adjustment set if no element of Z can be removed without breaking the constructive back-door
+        criterion.
 
         Reference: Separators and adjustment sets in causal graphs: Complete criteria and an algorithmic framework,
         Zander et al., 2019, Corollary 5, p.19)
@@ -253,7 +264,7 @@ class CausalDAG(nx.DiGraph):
 
     def constructive_backdoor_criterion(self, proper_backdoor_graph: 'CausalDAG', treatments: [str], outcomes: [str],
                                         covariates: [str]) -> bool:
-        """ A variation of Pearl's back-door criterion applied to a proper_backdoor_graph which enables more efficient
+        """ A variation of Pearl's back-door criterion applied to a proper backdoor graph which enables more efficient
         computation of minimal adjustment sets for the effect of a set of treatments on a set of outcomes.
 
         The constructive back-door criterion is satisfied for a causal DAG G, a set of treatments X, a set of outcomes
@@ -293,6 +304,7 @@ class CausalDAG(nx.DiGraph):
 
     def proper_causal_pathway(self, treatments: [str], outcomes: [str]) -> [str]:
         """ Given a list of treatments and outcomes, compute the proper causal pathways between them.
+
         PCP(X, Y) = {DeX^(X) - X} intersect AnX_(Y)}, where:
         - DeX^(X) refers to the descendents of X in the graph obtained by deleting all edges into X.
         - AnX_(Y) refers to the ancestors of Y in the graph obtained by deleting all edges leaving X.

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -5,9 +5,10 @@ from causal_testing.specification.causal_dag import CausalDAG, close_separator, 
 
 
 class TestCausalDAG(unittest.TestCase):
+    """Test the CausalDAG class for creation of Causal Directed Acyclic Graphs (DAGs).
 
-    """Test the CausalDAG class to confirm whether it creates valid causal directed acyclic graphs and refuses to
-    create invalid (cycle-containing) graphs, as well as the methods for identifying adjustment sets."""
+    In particular, confirm whether the Causal DAG class creates valid causal directed acyclic graphs (empty and directed
+    graphs without cycles) and refuses to create invalid (cycle-containing) graphs."""
 
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
@@ -39,6 +40,7 @@ class TestCausalDAG(unittest.TestCase):
 
 
 class TestDAGIdentification(unittest.TestCase):
+    """Test the Causal DAG identification algorithms and supporting algorithms."""
 
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
@@ -67,8 +69,7 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertTrue(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_constructive_backdoor_criterion_should_not_hold_not_d_separator_in_proper_backdoor_graph(self):
-        """Test whether the constructive criterion holds when the adjustment set Z is not a d-separator in the proper
-        back-door graph."""
+        """Test whether the constructive criterion fails when the adjustment set is not a d-separator."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], ['V']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
@@ -110,7 +111,7 @@ class TestDAGIdentification(unittest.TestCase):
                                                             ('Z', 'Y')])
 
     def test_get_ancestor_graph_of_proper_backdoor_graph(self):
-        """Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
+        """Test whether get_ancestor_graph converts a CausalDAG to the correct proper back-door graph."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
@@ -119,16 +120,14 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual(list(ancestor_graph.graph.edges), [('X1', 'X2'), ('D1', 'Y'), ('Z', 'X2'), ('Z', 'Y')])
 
     def test_enumerate_minimal_adjustment_sets(self):
-        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum sized adjustment sets for a
-        CausalDAG."""
+        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum sized adjustment sets."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
         self.assertEqual([{'Z'}], adjustment_sets)
 
     def test_enumerate_minimal_adjustment_sets_multiple(self):
-        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
-        DAG."""
+        """Test whether enumerate_minimal_adjustment_sets lists all minimum adjustment sets if multiple are possible."""
         causal_dag = CausalDAG()
         causal_dag.graph.add_edges_from([('X1', 'X2'),
                                          ('X2', 'V'),
@@ -171,9 +170,11 @@ class TestDAGIdentification(unittest.TestCase):
 
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):
+    """ Test the graph algorithms designed for the undirected graph variants of a Causal DAG.
 
-    """Test the graph algorithms designed for the undirected graph variants of a Causal DAG (ancestor and moral graphs
-    that are generated as part of the list minimal adjustment sets algorithm."""
+    During the identification process, a Causal DAG is converted into several forms of undirected graph which allow for
+    more efficient computation of minimal separators. This suite of tests covers the two main algorithms applied to
+    these forms of undirected graphs (ancestor and moral graphs): close_separator and list_all_min_sep."""
 
     def setUp(self) -> None:
         self.graph = nx.Graph()

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -56,11 +56,7 @@ class TestDAGIdentification(unittest.TestCase):
         f.close()
 
     def test_proper_backdoor_graph(self):
-        """Test whether converting a Causal DAG to a proper back-door graph works correctly.
-
-        A proper back-door graph should remove the first edge from all proper causal paths from X to Y, where
-        X is the set of treatments and Y is the set of outcomes.
-        """
+        """Test whether converting a Causal DAG to a proper back-door graph works correctly."""
         causal_dag = CausalDAG(self.dag_dot_path)
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(['X1', 'X2'], ['Y'])
         self.assertEqual(list(proper_backdoor_graph.graph.edges),

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -5,6 +5,7 @@ from causal_testing.specification.causal_dag import CausalDAG, close_separator, 
 
 
 class TestCausalDAG(unittest.TestCase):
+
     """Test the CausalDAG class for creation of Causal Directed Acyclic Graphs (DAGs).
 
     In particular, confirm whether the Causal DAG class creates valid causal directed acyclic graphs (empty and directed
@@ -40,6 +41,7 @@ class TestCausalDAG(unittest.TestCase):
 
 
 class TestDAGIdentification(unittest.TestCase):
+
     """Test the Causal DAG identification algorithms and supporting algorithms."""
 
     def setUp(self) -> None:
@@ -50,7 +52,7 @@ class TestDAGIdentification(unittest.TestCase):
         f.close()
 
     def test_proper_backdoor_graph(self):
-        """ Test whether converting a Causal DAG to a proper back-door graph works correctly.
+        """Test whether converting a Causal DAG to a proper back-door graph works correctly.
 
         A proper back-door graph should remove the first edge from all proper causal paths from X to Y, where
         X is the set of treatments and Y is the set of outcomes.
@@ -144,8 +146,7 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual({frozenset({'Z1'}), frozenset({'Z2'}), frozenset({'Z3'})}, set_of_adjustment_sets)
 
     def test_enumerate_minimal_adjustment_sets_two_adjustments(self):
-        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
-        DAG."""
+        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets of arity two."""
         causal_dag = CausalDAG()
         causal_dag.graph.add_edges_from([('X1', 'X2'),
                                          ('X2', 'V'),
@@ -170,6 +171,7 @@ class TestDAGIdentification(unittest.TestCase):
 
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):
+
     """ Test the graph algorithms designed for the undirected graph variants of a Causal DAG.
 
     During the identification process, a Causal DAG is converted into several forms of undirected graph which allow for

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -118,7 +118,8 @@ class TestDAGIdentification(unittest.TestCase):
         CausalDAG. """
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
-        causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
+        adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
+        print(list(adjustment_sets))
 
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)
@@ -140,9 +141,12 @@ class TestUndirectedGraphAlgorithms(unittest.TestCase):
         self.assertEqual({2, 3}, result)
 
     def test_list_all_min_sep(self):
-        min_separators = list_all_min_sep(self.graph, self.treatment_node, self.outcome_node, self.treatment_node_set,
-                                          self.outcome_node_set)
-        print(min_separators)
+        min_separators = list(list_all_min_sep(self.graph, self.treatment_node, self.outcome_node,
+                                               self.treatment_node_set, self.outcome_node_set))
+
+        # Convert list of sets to set of frozen sets for comparison
+        min_separators = set(frozenset(min_separator) for min_separator in min_separators)
+        self.assertEqual({frozenset({2, 3}), frozenset({3, 4}), frozenset({4, 5})}, min_separators)
 
 
 if __name__ == '__main__':

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -1,7 +1,8 @@
 import unittest
 import os
 import networkx as nx
-from causal_testing.specification.causal_specification import CausalDAG
+import numpy as np
+from causal_testing.specification.causal_dag import CausalDAG, close_separator, list_all_min_sep
 
 
 class TestCausalDAG(unittest.TestCase):
@@ -112,8 +113,36 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual(list(ancestor_graph.graph.nodes), ['X1', 'X2', 'D1', 'Y', 'Z'])
         self.assertEqual(list(ancestor_graph.graph.edges), [('X1', 'X2'), ('D1', 'Y'), ('Z', 'X2'), ('Z', 'Y')])
 
+    def test_enumerate_minimal_adjustment_sets(self):
+        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum sized adjustment sets for a
+        CausalDAG. """
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys = ['X1', 'X2'], ['Y']
+        causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
+
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)
+
+
+class TestUndirectedGraphAlgorithms(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.graph = nx.Graph()
+        self.graph.add_edges_from([('a', 2), ('a', 3), (2, 4), (3, 5), (3, 4), (4, 'b'), (5, 'b')])
+        self.treatment_node = 'a'
+        self.outcome_node = 'b'
+        self.treatment_node_set = {'a'}
+        self.outcome_node_set = set(nx.neighbors(self.graph, 'b'))
+        self.outcome_node_set.add('b')
+
+    def test_close_separator(self):
+        result = close_separator(self.graph, self.treatment_node, self.outcome_node, self.treatment_node_set)
+        self.assertEqual({2, 3}, result)
+
+    def test_list_all_min_sep(self):
+        min_separators = list_all_min_sep(self.graph, self.treatment_node, self.outcome_node, self.treatment_node_set,
+                                          self.outcome_node_set)
+        print(min_separators)
 
 
 if __name__ == '__main__':

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -119,7 +119,25 @@ class TestDAGIdentification(unittest.TestCase):
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
-        print(list(adjustment_sets))
+        self.assertEqual([{'Z'}], adjustment_sets)
+
+    def test_enumerate_minimal_adjustment_sets_multiple(self):
+        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
+        DAG. """
+        causal_dag = CausalDAG()
+        causal_dag.graph.add_edges_from([('X1', 'X2'),
+                                         ('X2', 'V'),
+                                         ('Z1', 'X2'),
+                                         ('Z1', 'Z2'),
+                                         ('Z2', 'Z3'),
+                                         ('Z3', 'Y'),
+                                         ('D1', 'Y'),
+                                         ('D1', 'D2'),
+                                         ('Y', 'D3')])
+        xs, ys = ['X1', 'X2'], ['Y']
+        adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
+        set_of_adjustment_sets = set(frozenset(min_separator) for min_separator in adjustment_sets)
+        self.assertEqual({frozenset({'Z1'}), frozenset({'Z2'}), frozenset({'Z3'})}, set_of_adjustment_sets)
 
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -139,6 +139,28 @@ class TestDAGIdentification(unittest.TestCase):
         set_of_adjustment_sets = set(frozenset(min_separator) for min_separator in adjustment_sets)
         self.assertEqual({frozenset({'Z1'}), frozenset({'Z2'}), frozenset({'Z3'})}, set_of_adjustment_sets)
 
+    def test_enumerate_minimal_adjustment_sets_two_adjustments(self):
+        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
+        DAG. """
+        causal_dag = CausalDAG()
+        causal_dag.graph.add_edges_from([('X1', 'X2'),
+                                         ('X2', 'V'),
+                                         ('Z1', 'X2'),
+                                         ('Z1', 'Z2'),
+                                         ('Z2', 'Z3'),
+                                         ('Z3', 'Y'),
+                                         ('D1', 'Y'),
+                                         ('D1', 'D2'),
+                                         ('Y', 'D3'),
+                                         ('Z4', 'X1'),
+                                         ('Z4', 'Y'),
+                                         ('X2', 'D1')])
+        xs, ys = ['X1', 'X2'], ['Y']
+        adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
+        set_of_adjustment_sets = set(frozenset(min_separator) for min_separator in adjustment_sets)
+        self.assertEqual({frozenset({'Z1', 'Z4'}), frozenset({'Z2', 'Z4'}), frozenset({'Z3', 'Z4'})},
+                         set_of_adjustment_sets)
+
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)
 

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -1,7 +1,6 @@
 import unittest
 import os
 import networkx as nx
-import numpy as np
 from causal_testing.specification.causal_dag import CausalDAG, close_separator, list_all_min_sep
 
 
@@ -15,6 +14,7 @@ class TestCausalDAG(unittest.TestCase):
         f.close()
 
     def test_valid_causal_dag(self):
+        """Test whether the Causal DAG is valid."""
         causal_dag = CausalDAG(self.dag_dot_path)
         assert list(causal_dag.graph.nodes) == ['A', 'B', 'C', 'D'] and list(causal_dag.graph.edges) == [('A', 'B'),
                                                                                                          ('B', 'C'),
@@ -22,10 +22,12 @@ class TestCausalDAG(unittest.TestCase):
                                                                                                          ('D', 'C')]
 
     def test_invalid_causal_dag(self):
+        """Test whether a cycle-containing directed graph is an invalid causal DAG."""
         causal_dag = CausalDAG(self.dag_dot_path)
         self.assertRaises(nx.HasACycle, causal_dag.add_edge, 'C', 'A')
 
     def test_empty_casual_dag(self):
+        """Test whether an empty dag can be created."""
         causal_dag = CausalDAG()
         assert list(causal_dag.graph.nodes) == [] and list(causal_dag.graph.edges) == []
 
@@ -43,8 +45,7 @@ class TestDAGIdentification(unittest.TestCase):
         f.close()
 
     def test_proper_backdoor_graph(self):
-        """
-        Test whether converting a Causal DAG to a proper back-door graph works correctly.
+        """ Test whether converting a Causal DAG to a proper back-door graph works correctly.
         A proper back-door graph should remove the first edge from all proper causal paths from X to Y, where
         X is the set of treatments and Y is the set of outcomes.
         """
@@ -55,48 +56,48 @@ class TestDAGIdentification(unittest.TestCase):
                           ('Z', 'Y')])
 
     def test_constructive_backdoor_criterion_should_hold(self):
-        """ Test whether the constructive criterion holds when it should. """
+        """Test whether the constructive criterion holds when it should."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], ['Z']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
         self.assertTrue(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_constructive_backdoor_criterion_should_not_hold_not_d_separator_in_proper_backdoor_graph(self):
-        """ Test whether the constructive criterion holds when the adjustment set Z is not a d-separator in the proper
-        back-door graph. """
+        """Test whether the constructive criterion holds when the adjustment set Z is not a d-separator in the proper
+        back-door graph."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], ['V']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
         self.assertFalse(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_constructive_backdoor_criterion_should_not_hold_descendent_of_proper_causal_path(self):
-        """ Test whether the constructive criterion holds when the adjustment set Z contains a descendent of a variable
-        on a proper causal path between X and Y. """
+        """Test whether the constructive criterion holds when the adjustment set Z contains a descendent of a variable
+        on a proper causal path between X and Y."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], ['D1']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
         self.assertFalse(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_is_min_adjustment_for_min_adjustment(self):
-        """ Test whether is_min_adjustment can correctly test whether the minimum adjustment set is minimal."""
+        """Test whether is_min_adjustment can correctly test whether the minimum adjustment set is minimal."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], {'Z'}
         self.assertTrue(causal_dag.adjustment_set_is_minimal(xs, ys, zs))
 
     def test_is_min_adjustment_for_not_min_adjustment(self):
-        """ Test whether is_min_adjustment can correctly test whether the minimum adjustment set is not minimal."""
+        """Test whether is_min_adjustment can correctly test whether the minimum adjustment set is not minimal."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], {'Z', 'V'}
         self.assertFalse(causal_dag.adjustment_set_is_minimal(xs, ys, zs))
 
     def test_is_min_adjustment_for_invalid_adjustment(self):
-        """ Test whether is min_adjustment can correctly identify that the minimum adjustment set is invalid."""
+        """Test whether is min_adjustment can correctly identify that the minimum adjustment set is invalid."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys, zs = ['X1', 'X2'], ['Y'], set()
         self.assertRaises(ValueError, causal_dag.adjustment_set_is_minimal, xs, ys, zs)
 
     def test_get_ancestor_graph_of_causal_dag(self):
-        """ Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
+        """Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         ancestor_graph = causal_dag.get_ancestor_graph(xs, ys)
@@ -105,7 +106,7 @@ class TestDAGIdentification(unittest.TestCase):
                                                             ('Z', 'Y')])
 
     def test_get_ancestor_graph_of_proper_backdoor_graph(self):
-        """ Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
+        """Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
@@ -122,8 +123,8 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual([{'Z'}], adjustment_sets)
 
     def test_enumerate_minimal_adjustment_sets_multiple(self):
-        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
-        DAG. """
+        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
+        DAG."""
         causal_dag = CausalDAG()
         causal_dag.graph.add_edges_from([('X1', 'X2'),
                                          ('X2', 'V'),
@@ -140,8 +141,8 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual({frozenset({'Z1'}), frozenset({'Z2'}), frozenset({'Z3'})}, set_of_adjustment_sets)
 
     def test_enumerate_minimal_adjustment_sets_two_adjustments(self):
-        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
-        DAG. """
+        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum adjustment sets in the M-bias
+        DAG."""
         causal_dag = CausalDAG()
         causal_dag.graph.add_edges_from([('X1', 'X2'),
                                          ('X2', 'V'),
@@ -177,10 +178,12 @@ class TestUndirectedGraphAlgorithms(unittest.TestCase):
         self.outcome_node_set.add('b')
 
     def test_close_separator(self):
+        """Test whether close_separator correctly identifies the close separator of {2,3} in the undirected graph."""
         result = close_separator(self.graph, self.treatment_node, self.outcome_node, self.treatment_node_set)
         self.assertEqual({2, 3}, result)
 
     def test_list_all_min_sep(self):
+        """Test whether list_all_min_sep finds all minimal separators for the undirected graph relative to a and b."""
         min_separators = list(list_all_min_sep(self.graph, self.treatment_node, self.outcome_node,
                                                self.treatment_node_set, self.outcome_node_set))
 

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -94,6 +94,24 @@ class TestDAGIdentification(unittest.TestCase):
         xs, ys, zs = ['X1', 'X2'], ['Y'], set()
         self.assertRaises(ValueError, causal_dag.adjustment_set_is_minimal, xs, ys, zs)
 
+    def test_get_ancestor_graph_of_causal_dag(self):
+        """ Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys = ['X1', 'X2'], ['Y']
+        ancestor_graph = causal_dag.get_ancestor_graph(xs, ys)
+        self.assertEqual(list(ancestor_graph.graph.nodes), ['X1', 'X2', 'D1', 'Y', 'Z'])
+        self.assertEqual(list(ancestor_graph.graph.edges), [('X1', 'X2'), ('X2', 'D1'), ('D1', 'Y'), ('Z', 'X2'),
+                                                            ('Z', 'Y')])
+
+    def test_get_ancestor_graph_of_proper_backdoor_graph(self):
+        """ Test whether get_ancestor_graph converts a CausalDAG to the correct ancestor graph."""
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys = ['X1', 'X2'], ['Y']
+        proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
+        ancestor_graph = proper_backdoor_graph.get_ancestor_graph(xs, ys)
+        self.assertEqual(list(ancestor_graph.graph.nodes), ['X1', 'X2', 'D1', 'Y', 'Z'])
+        self.assertEqual(list(ancestor_graph.graph.edges), [('X1', 'X2'), ('D1', 'Y'), ('Z', 'X2'), ('Z', 'Y')])
+
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)
 

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -32,7 +32,7 @@ class TestCausalDAG(unittest.TestCase):
         os.remove(self.dag_dot_path)
 
 
-class TestGraphTransformations(unittest.TestCase):
+class TestDAGIdentification(unittest.TestCase):
 
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
@@ -75,6 +75,24 @@ class TestGraphTransformations(unittest.TestCase):
         xs, ys, zs = ['X1', 'X2'], ['Y'], ['D1']
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(xs, ys)
         self.assertFalse(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
+
+    def test_is_min_adjustment_for_min_adjustment(self):
+        """ Test whether is_min_adjustment can correctly test whether the minimum adjustment set is minimal."""
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys, zs = ['X1', 'X2'], ['Y'], {'Z'}
+        self.assertTrue(causal_dag.adjustment_set_is_minimal(xs, ys, zs))
+
+    def test_is_min_adjustment_for_not_min_adjustment(self):
+        """ Test whether is_min_adjustment can correctly test whether the minimum adjustment set is not minimal."""
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys, zs = ['X1', 'X2'], ['Y'], {'Z', 'V'}
+        self.assertFalse(causal_dag.adjustment_set_is_minimal(xs, ys, zs))
+
+    def test_is_min_adjustment_for_invalid_adjustment(self):
+        """ Test whether is min_adjustment can correctly identify that the minimum adjustment set is invalid."""
+        causal_dag = CausalDAG(self.dag_dot_path)
+        xs, ys, zs = ['X1', 'X2'], ['Y'], set()
+        self.assertRaises(ValueError, causal_dag.adjustment_set_is_minimal, xs, ys, zs)
 
     def tearDown(self) -> None:
         os.remove(self.dag_dot_path)

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -6,10 +6,12 @@ from causal_testing.specification.causal_dag import CausalDAG, close_separator, 
 
 class TestCausalDAG(unittest.TestCase):
 
-    """Test the CausalDAG class for creation of Causal Directed Acyclic Graphs (DAGs).
+    """
+    Test the CausalDAG class for creation of Causal Directed Acyclic Graphs (DAGs).
 
     In particular, confirm whether the Causal DAG class creates valid causal directed acyclic graphs (empty and directed
-    graphs without cycles) and refuses to create invalid (cycle-containing) graphs."""
+    graphs without cycles) and refuses to create invalid (cycle-containing) graphs.
+    """
 
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
@@ -42,7 +44,9 @@ class TestCausalDAG(unittest.TestCase):
 
 class TestDAGIdentification(unittest.TestCase):
 
-    """Test the Causal DAG identification algorithms and supporting algorithms."""
+    """
+    Test the Causal DAG identification algorithms and supporting algorithms.
+    """
 
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
@@ -172,7 +176,8 @@ class TestDAGIdentification(unittest.TestCase):
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):
 
-    """ Test the graph algorithms designed for the undirected graph variants of a Causal DAG.
+    """
+    Test the graph algorithms designed for the undirected graph variants of a Causal DAG.
 
     During the identification process, a Causal DAG is converted into several forms of undirected graph which allow for
     more efficient computation of minimal separators. This suite of tests covers the two main algorithms applied to

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -6,6 +6,9 @@ from causal_testing.specification.causal_dag import CausalDAG, close_separator, 
 
 class TestCausalDAG(unittest.TestCase):
 
+    """Test the CausalDAG class to confirm whether it creates valid causal directed acyclic graphs and refuses to
+    create invalid (cycle-containing) graphs, as well as the methods for identifying adjustment sets."""
+
     def setUp(self) -> None:
         self.dag_dot_path = 'temp/dag.dot'
         dag_dot = """digraph G { A -> B; B -> C; D -> A; D -> C}"""
@@ -46,6 +49,7 @@ class TestDAGIdentification(unittest.TestCase):
 
     def test_proper_backdoor_graph(self):
         """ Test whether converting a Causal DAG to a proper back-door graph works correctly.
+
         A proper back-door graph should remove the first edge from all proper causal paths from X to Y, where
         X is the set of treatments and Y is the set of outcomes.
         """
@@ -115,8 +119,8 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertEqual(list(ancestor_graph.graph.edges), [('X1', 'X2'), ('D1', 'Y'), ('Z', 'X2'), ('Z', 'Y')])
 
     def test_enumerate_minimal_adjustment_sets(self):
-        """ Test whether enumerate_minimal_adjustment_sets lists all possible minimum sized adjustment sets for a
-        CausalDAG. """
+        """Test whether enumerate_minimal_adjustment_sets lists all possible minimum sized adjustment sets for a
+        CausalDAG."""
         causal_dag = CausalDAG(self.dag_dot_path)
         xs, ys = ['X1', 'X2'], ['Y']
         adjustment_sets = causal_dag.enumerate_minimal_adjustment_sets(xs, ys)
@@ -167,6 +171,9 @@ class TestDAGIdentification(unittest.TestCase):
 
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):
+
+    """Test the graph algorithms designed for the undirected graph variants of a Causal DAG (ancestor and moral graphs
+    that are generated as part of the list minimal adjustment sets algorithm."""
 
     def setUp(self) -> None:
         self.graph = nx.Graph()


### PR DESCRIPTION
## Overview
I have implemented and tested an algorithm for listing minimal adjustment sets given a causal DAG, a set of treatment variables, and a set of outcome variables. The main algorithm used in this implementation is presented in [1] but a simpler version can be found in the earlier conference version [2]. This is the algorithm used by Dagitty which is significantly faster than DoWhy for identification. However, Dagitty is only available as an R package so to reduce dependencies it made sense to implement it for ourselves.

At a high-level, the algorithm works as follows:
1. Convert the DAG to a proper back-door graph, relative to the specified treatments (X) and outcomes (Y) [1].
2. Convert the proper back-door graph into an ancestor graph, relative to X and Y [1, 2].
3. Convert the ancestor graph into a moralised graph [1, 2].
4. Add a node XM which is connected to all variables in X [1].
5. Add a node YM which is connected to all variables in Y [1].
6. Remove all nodes in X and Y from the graph and connect their neighbours [1].
7. Apply Takata's list minimum separators algorithm [3] to the resulting graph [1, 2].
8. Return the set of minimum separators -- these are equivalent to adjustment sets in the original DAG [1].

All of the methods used in this algorithm have been implemented in the `CausalDAG` class, with the exception of two methods which only apply to the undirected graphs used in steps 2 and 3. These are currently in `causal_dag.py` but outside of the `CausalDAG` class. We can these a better home (e.g. helper functions library) in the future. All methods have also been unit tested in the `tests/specification_tests/test_causal_dag.py` achieving 96% coverage over `causal_dag.py`.


## TODO:

- [ ] Check guidelines are met (not quite finalised yet).
- [ ] Work out how to set-up continuous integration and automatic coverage report upon PR.

## References
[1] [Zander et al., Separators and adjustment sets in causal graphs: Complete criteria and an algorithmic framework, 2019](https://www.sciencedirect.com/science/article/pii/S0004370219300025?casa_token=EYziiE_8VuYAAAAA:ArtIagD0Jyh6_Hfb69RAnchlqrRaundthGdqNMpr6imoWEEZD9zAmoEOKXLopLGM6KwttCkB-wM)
[2] [Textor and Liskiewicz, Adjustment Criteria in Causal Diagrams: An Algorithmic Perspective, 2012](https://arxiv.org/abs/1202.3764)
[3] [Ken Takata, Space-optimal, backtracking algorithms to list the minimal vertex separators of a graph, 2010](https://www.sciencedirect.com/science/article/pii/S0166218X10001824)