### PR TITLE
Tests now handle temp file setup and teardown correctly

### DIFF
--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import networkx as nx
 from causal_testing.specification.causal_dag import CausalDAG, close_separator, list_all_min_sep
+from tests.test_helpers import create_temp_dir_if_non_existent, remove_temp_dir_if_existent
 
 
 class TestCausalDAG(unittest.TestCase):
@@ -14,7 +15,8 @@ class TestCausalDAG(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.dag_dot_path = 'temp/dag.dot'
+        temp_dir_path = create_temp_dir_if_non_existent()
+        self.dag_dot_path = os.path.join(temp_dir_path, 'dag.dot')
         dag_dot = """digraph G { A -> B; B -> C; D -> A; D -> C}"""
         f = open(self.dag_dot_path, 'w')
         f.write(dag_dot)
@@ -23,6 +25,7 @@ class TestCausalDAG(unittest.TestCase):
     def test_valid_causal_dag(self):
         """Test whether the Causal DAG is valid."""
         causal_dag = CausalDAG(self.dag_dot_path)
+        print(causal_dag)
         assert list(causal_dag.graph.nodes) == ['A', 'B', 'C', 'D'] and list(causal_dag.graph.edges) == [('A', 'B'),
                                                                                                          ('B', 'C'),
                                                                                                          ('D', 'A'),
@@ -39,7 +42,7 @@ class TestCausalDAG(unittest.TestCase):
         assert list(causal_dag.graph.nodes) == [] and list(causal_dag.graph.edges) == []
 
     def tearDown(self) -> None:
-        os.remove(self.dag_dot_path)
+        remove_temp_dir_if_existent()
 
 
 class TestDAGIdentification(unittest.TestCase):
@@ -49,7 +52,8 @@ class TestDAGIdentification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.dag_dot_path = 'temp/dag.dot'
+        temp_dir_path = create_temp_dir_if_non_existent()
+        self.dag_dot_path = os.path.join(temp_dir_path, 'dag.dot')
         dag_dot = """digraph G { X1->X2;X2->V;X2->D1;X2->D2;D1->Y;D1->D2;Y->D3;Z->X2;Z->Y;}"""
         f = open(self.dag_dot_path, 'w')
         f.write(dag_dot)
@@ -167,7 +171,7 @@ class TestDAGIdentification(unittest.TestCase):
                          set_of_adjustment_sets)
 
     def tearDown(self) -> None:
-        os.remove(self.dag_dot_path)
+        remove_temp_dir_if_existent()
 
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -205,7 +205,3 @@ class TestUndirectedGraphAlgorithms(unittest.TestCase):
         # Convert list of sets to set of frozen sets for comparison
         min_separators = set(frozenset(min_separator) for min_separator in min_separators)
         self.assertEqual({frozenset({2, 3}), frozenset({3, 4}), frozenset({4, 5})}, min_separators)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,8 +6,11 @@ from shutil import rmtree
 
 
 def create_temp_dir_if_non_existent():
-    """
-    Create a temporary directory in the current working directory if one does not exist already and return path.
+    """Create a temporary directory in the current working directory if one does not exist already.
+
+    Create a temporary directory named temp in the current working directory provided it does not already exist, and
+    then return the path to the temporary directory (regardless of whether it existed previously or has just been
+    created).
 
     :return: Path to the temporary directory.
     """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,8 @@ from shutil import rmtree
 
 
 def create_temp_dir_if_non_existent():
-    """Create a temporary directory in the current working directory if one does not exist already and return path.
+    """
+    Create a temporary directory in the current working directory if one does not exist already and return path.
 
     :return: Path to the temporary directory.
     """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,23 @@
+"""A library of helper methods for the causal testing framework tests."""
+import sys
+from os import mkdir
+from os.path import join, dirname, realpath, exists
+from shutil import rmtree
+
+
+def create_temp_dir_if_non_existent():
+    """Create a temporary directory in the current working directory if one does not exist already and return path.
+
+    :return: Path to the temporary directory.
+    """
+    temp_dir = join(dirname(realpath(sys.argv[0])), 'temp/')
+    if not exists(temp_dir):
+        mkdir(temp_dir)
+    return temp_dir
+
+
+def remove_temp_dir_if_existent():
+    """Remove a temporary directory from the current working directory if one exists."""
+    temp_dir = join(dirname(realpath(sys.argv[0])), 'temp/')
+    if exists(temp_dir):
+        rmtree(temp_dir)


### PR DESCRIPTION
Closes #11. 

In setup, we now check if a temp dir exists and create one if not. In teardown, we now check if a temp dir exists and remove it if so.

@bobturneruk I had a look at `tempdir` but it didn't work well with `setUp` and `tearDown`. Using `tempdir`, I believe you would have to create a temp directory for each method in a test class since it removes the temp dir after the method is executed automatically. I may have been using it wrong though!
