### PR TITLE
Change CI to test on python 3.9 only

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python using Miniconda


### PR DESCRIPTION
Removes python 3.10 from `python-version` since some of our dependencies do not support python 3.10 at this time.