### PR TITLE
z3 dependency fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "scipy~=1.7.3",
     "statsmodels~=0.13.2",
     "tabulate~=0.8.10",
-    "z3_solver>=4.11.2",
+    "z3_solver~=4.11.2",
 ]
 
 # Additional dependencies for development

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "scipy~=1.7.3",
     "statsmodels~=0.13.2",
     "tabulate~=0.8.10",
-    "z3_solver~=4.8.13.0",
+    "z3_solver>=4.11.2",
 ]
 
 # Additional dependencies for development


### PR DESCRIPTION
closes #107 

Updated dependency to fix bug related to https://github.com/Z3Prover/z3/issues/5656

Framework no longer throws errors on shutting down z3 variables