### PR TITLE
Causal test case refactor

### DIFF
--- a/causal_testing/generation/abstract_causal_test_case.py
+++ b/causal_testing/generation/abstract_causal_test_case.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class AbstractCausalTestCase:
     """
-    An abstract test case serves as a generator for concrete test cases. Instead of having concrete conctrol
+    An abstract test case serves as a generator for concrete test cases. Instead of having concrete control
     and treatment values, we instead just specify the intervention and the treatment variables. This then
     enables potentially infinite concrete test cases to be generated between different values of the treatment.
     """

--- a/causal_testing/generation/abstract_causal_test_case.py
+++ b/causal_testing/generation/abstract_causal_test_case.py
@@ -229,8 +229,8 @@ class AbstractCausalTestCase:
                     for var in effect_modifier_configs.columns
                 }
             )
-            control_values = [test.control_input_configuration[self.treatment_variable] for test in concrete_tests]
-            treatment_values = [test.treatment_input_configuration[self.treatment_variable] for test in concrete_tests]
+            control_values = [test.control_value for test in concrete_tests]
+            treatment_values = [test.treatment_value for test in concrete_tests]
 
             if self.treatment_variable.datatype is bool and set([(True, False), (False, True)]).issubset(
                 set(zip(control_values, treatment_values))

--- a/causal_testing/generation/abstract_causal_test_case.py
+++ b/causal_testing/generation/abstract_causal_test_case.py
@@ -141,7 +141,8 @@ class AbstractCausalTestCase:
             # Treatment run
             if rct:
                 treatment_run = control_run.copy()
-                treatment_run.update({k.name: v for k, v in concrete_test.treatment_input_configuration.items()})
+                treatment_run.update({concrete_test.treatment_variable.name: concrete_test.treatment_value})
+                #treatment_run.update({k.name: v for k, v in concrete_test.treatment_input_configuration.items()})
                 treatment_run["bin"] = index
                 runs.append(treatment_run)
 
@@ -185,7 +186,7 @@ class AbstractCausalTestCase:
             runs = pd.concat([runs, runs_])
             assert concrete_tests_ not in concrete_tests, "Duplicate entries unlikely unless something went wrong"
 
-            control_configs = pd.DataFrame([test.control_input_configuration for test in concrete_tests])
+            control_configs = pd.DataFrame([{test.treatment_variable: test.control_value} for test in concrete_tests])
             ks_stats = {
                 var: stats.kstest(control_configs[var], var.distribution.cdf).statistic
                 for var in control_configs.columns

--- a/causal_testing/generation/abstract_causal_test_case.py
+++ b/causal_testing/generation/abstract_causal_test_case.py
@@ -142,7 +142,7 @@ class AbstractCausalTestCase:
             if rct:
                 treatment_run = control_run.copy()
                 treatment_run.update({concrete_test.treatment_variable.name: concrete_test.treatment_value})
-                #treatment_run.update({k.name: v for k, v in concrete_test.treatment_input_configuration.items()})
+                # treatment_run.update({k.name: v for k, v in concrete_test.treatment_input_configuration.items()})
                 treatment_run["bin"] = index
                 runs.append(treatment_run)
 

--- a/causal_testing/generation/abstract_causal_test_case.py
+++ b/causal_testing/generation/abstract_causal_test_case.py
@@ -146,7 +146,6 @@ class AbstractCausalTestCase:
                         + f"{constraints}\nUsing value {v.cast(model[v.z3])} instead in test\n{concrete_test}"
                     )
 
-
             if not any([vars(t) == vars(concrete_test) for t in concrete_tests]):
                 concrete_tests.append(concrete_test)
                 # Control run
@@ -161,7 +160,6 @@ class AbstractCausalTestCase:
                     treatment_run.update({concrete_test.treatment_variable.name: concrete_test.treatment_value})
                     treatment_run["bin"] = index
                     runs.append(treatment_run)
-
 
         return concrete_tests, pd.DataFrame(runs, columns=run_columns + ["bin"])
 

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -206,12 +206,12 @@ class JsonUtility(ABC):
         data_collector = ObservationalDataCollector(self.modelling_scenario, self.data_path)
         causal_test_engine = CausalTestEngine(self.causal_specification, data_collector, index_col=0)
         minimal_adjustment_set = self.causal_specification.causal_dag.identification(causal_test_case.base_test_case)
-        treatment_vars = list(causal_test_case.treatment_input_configuration)
-        minimal_adjustment_set = minimal_adjustment_set - {v.name for v in treatment_vars}
+        treatment_var = causal_test_case.treatment_variable
+        minimal_adjustment_set = minimal_adjustment_set - {treatment_var}
         estimation_model = estimator(
-            (list(treatment_vars)[0].name,),
-            [causal_test_case.treatment_input_configuration[v] for v in treatment_vars][0],
-            [causal_test_case.control_input_configuration[v] for v in treatment_vars][0],
+            (treatment_var.name,),
+            causal_test_case.treatment_value,
+            causal_test_case.control_value,
             minimal_adjustment_set,
             (causal_test_case.outcome_variable.name,),
             causal_test_engine.scenario_execution_data_df,

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -468,7 +468,7 @@ class CausalDAG(nx.DiGraph):
     def identification(self, base_test_case):
         """Identify and return the minimum adjustment set
 
-        :param base_test_case: A base test case class instance containing the outcome_variable and the
+        :param base_test_case: A base test case instance containing the outcome_variable and the
         treatment_variable required for identification.
         :return minimal_adjustment_set: The smallest set of variables which can be adjusted for to obtain a causal
         estimate as opposed to a purely associational estimate.

--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -59,11 +59,11 @@ class CausalTestCase:
         return self.outcome_variable.name
 
     def get_control_value(self):
-        """Return a list of the control values for each treatment variable in this causal test case."""
+        """Return a list of the control value for each treatment variable in this causal test case."""
         return self.control_value
 
     def get_treatment_value(self):
-        """Return a list of the treatment values for each treatment variable in this causal test case."""
+        """Return a list of the treatment value for each treatment variable in this causal test case."""
         return self.treatment_value
 
     def __str__(self):

--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -10,10 +10,14 @@ logger = logging.getLogger(__name__)
 
 class CausalTestCase:
     """
-    A causal test case is a triple (X, Delta, Y), where X is an input configuration, Delta is an intervention, and
-    Y is the expected causal effect on a particular output. The goal of a causal test case is to test whether the
-    intervention Delta made to the input configuration X causes the model-under-test to produce the expected change
-    in Y.
+    A CausalTestCase extends the information held in a BaseTestCase. As well as storing the treatment and outcome
+    variables, a CausalTestCase stores the values of these variables. Also the outcome variable and value are
+    specified.
+
+    The goal of a CausalTestCase is to test whether the intervention made to the control via the treatment causes the
+    model-under-test to produce the expected change. The CausalTestCase structure is designed for execution using the
+    CausalTestEngine, using either execute_test() function to execute a single test case or packing CausalTestCases into
+    a CausalTestSuite and executing them as a batch using the execute_test_suite() function.
     """
 
     def __init__(
@@ -26,15 +30,12 @@ class CausalTestCase:
         effect_modifier_configuration: dict[Variable:Any] = None,
     ):
         """
-        When a CausalTestCase is initialised, it takes the intervention and applies it to the input configuration to
-        create two distinct input configurations: a control input configuration and a treatment input configuration.
-        The former is the input configuration before applying the intervention and the latter is the input configuration
-        after applying the intervention.
-
-        :param control_input_configuration: The input configuration representing the control values of the treatment
-        variables.
-        :param treatment_input_configuration: The input configuration representing the treatment values of the treatment
-        variables. That is, the input configuration *after* applying the intervention.
+        :param base_test_case: A BaseTestCase object consisting of a treatment variable, outcome variable and effect
+        :param expected_causal_effect: The expected causal effect (Positive, Negative, No Effect).
+        :param control_value: The control value for the treatment variable (before intervention).
+        :param treatment_value: The treatment value for the treatment variable (after intervention).
+        :param estimate_type: A string which denotes the type of estimate to return
+        :param effect_modifier_configuration:
         """
         self.base_test_case = base_test_case
         self.control_value = control_value

--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class CausalTestCase:
-    """)
+    """
     A causal test case is a triple (X, Delta, Y), where X is an input configuration, Delta is an intervention, and
     Y is the expected causal effect on a particular output. The goal of a causal test case is to test whether the
     intervention Delta made to the input configuration X causes the model-under-test to produce the expected change
@@ -37,39 +37,38 @@ class CausalTestCase:
         variables. That is, the input configuration *after* applying the intervention.
         """
         self.base_test_case = base_test_case
-        self.control_input_configuration = {base_test_case.treatment_variable: control_value}
+        self.control_value = control_value
         self.expected_causal_effect = expected_causal_effect
         self.outcome_variable = base_test_case.outcome_variable
-        self.treatment_input_configuration = {base_test_case.treatment_variable: treatment_value}
+        self.treatment_variable = base_test_case.treatment_variable
+        self.treatment_value = treatment_value
         self.estimate_type = estimate_type
         self.effect = base_test_case.effect
+
         if effect_modifier_configuration:
             self.effect_modifier_configuration = effect_modifier_configuration
         else:
             self.effect_modifier_configuration = dict()
-        assert (
-            self.control_input_configuration.keys() == self.treatment_input_configuration.keys()
-        ), "Control and treatment input configurations must have the same keys."
 
-    def get_treatment_variables(self):
+    def get_treatment_variable(self):
         """Return a list of the treatment variables (as strings) for this causal test case."""
-        return [v.name for v in self.control_input_configuration]
+        return self.treatment_variable.name
 
-    def get_outcome_variables(self):
+    def get_outcome_variable(self):
         """Return a list of the outcome variables (as strings) for this causal test case."""
-        return [self.outcome_variable.name]
+        return self.outcome_variable.name
 
-    def get_control_values(self):
+    def get_control_value(self):
         """Return a list of the control values for each treatment variable in this causal test case."""
-        return list(self.control_input_configuration.values())
+        return self.control_value
 
-    def get_treatment_values(self):
+    def get_treatment_value(self):
         """Return a list of the treatment values for each treatment variable in this causal test case."""
-        return list(self.treatment_input_configuration.values())
+        return self.treatment_value
 
     def __str__(self):
-        treatment_config = {k.name: v for k, v in self.treatment_input_configuration.items()}
-        control_config = {k.name: v for k, v in self.control_input_configuration.items()}
+        treatment_config = {self.treatment_variable.name: self.treatment_value}
+        control_config = {self.treatment_variable.name: self.control_value}
         outcome_variable = {self.outcome_variable}
         return (
             f"Running {treatment_config} instead of {control_config} should cause the following "

--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -52,19 +52,19 @@ class CausalTestCase:
             self.effect_modifier_configuration = dict()
 
     def get_treatment_variable(self):
-        """Return a list of the treatment variables (as strings) for this causal test case."""
+        """Return the treatment variable name (as string) for this causal test case"""
         return self.treatment_variable.name
 
     def get_outcome_variable(self):
-        """Return a list of the outcome variables (as strings) for this causal test case."""
+        """Return the outcome variable name (as string) for this causal test case."""
         return self.outcome_variable.name
 
     def get_control_value(self):
-        """Return a list of the control value for each treatment variable in this causal test case."""
+        """Return a the control value of the treatment variable in this causal test case."""
         return self.control_value
 
     def get_treatment_value(self):
-        """Return a list of the treatment value for each treatment variable in this causal test case."""
+        """Return the treatment value of the treatment variable in this causal test case."""
         return self.treatment_value
 
     def __str__(self):

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -172,8 +172,8 @@ class CausalTestEngine:
                 causal_test_result = CausalTestResult(
                     treatment=estimator.treatment,
                     outcome=estimator.outcome,
-                    treatment_value=estimator.treatment_values,
-                    control_value=estimator.control_values,
+                    treatment_value=estimator.treatment_value,
+                    control_value=estimator.control_value,
                     adjustment_set=estimator.adjustment_set,
                     ate=cates_df,
                     effect_modifier_configuration=causal_test_case.effect_modifier_configuration,
@@ -185,8 +185,8 @@ class CausalTestEngine:
             causal_test_result = CausalTestResult(
                 treatment=estimator.treatment,
                 outcome=estimator.outcome,
-                treatment_value=estimator.treatment_values,
-                control_value=estimator.control_values,
+                treatment_value=estimator.treatment_value,
+                control_value=estimator.control_value,
                 adjustment_set=estimator.adjustment_set,
                 ate=risk_ratio,
                 effect_modifier_configuration=causal_test_case.effect_modifier_configuration,
@@ -198,8 +198,8 @@ class CausalTestEngine:
             causal_test_result = CausalTestResult(
                 treatment=estimator.treatment,
                 outcome=estimator.outcome,
-                treatment_value=estimator.treatment_values,
-                control_value=estimator.control_values,
+                treatment_value=estimator.treatment_value,
+                control_value=estimator.control_value,
                 adjustment_set=estimator.adjustment_set,
                 ate=ate,
                 effect_modifier_configuration=causal_test_case.effect_modifier_configuration,
@@ -213,8 +213,8 @@ class CausalTestEngine:
             causal_test_result = CausalTestResult(
                 treatment=estimator.treatment,
                 outcome=estimator.outcome,
-                treatment_value=estimator.treatment_values,
-                control_value=estimator.control_values,
+                treatment_value=estimator.treatment_value,
+                control_value=estimator.control_value,
                 adjustment_set=estimator.adjustment_set,
                 ate=ate,
                 effect_modifier_configuration=causal_test_case.effect_modifier_configuration,

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -131,19 +131,16 @@ class CausalTestEngine:
             raise Exception("No data has been loaded. Please call load_data prior to executing a causal test case.")
         if estimator.df is None:
             estimator.df = self.scenario_execution_data_df
-        treatment_variable = list(causal_test_case.control_input_configuration.keys())[0]
+        treatment_variable = causal_test_case.treatment_variable
         treatments = treatment_variable.name
         outcome_variable = causal_test_case.outcome_variable
 
         logger.info("treatments: %s", treatments)
         logger.info("outcomes: %s", outcome_variable)
         minimal_adjustment_set = self.causal_dag.identification(BaseTestCase(treatment_variable, outcome_variable))
-        minimal_adjustment_set = minimal_adjustment_set - {v.name for v in causal_test_case.control_input_configuration}
+        minimal_adjustment_set = minimal_adjustment_set - set(treatment_variable.name)
         minimal_adjustment_set = minimal_adjustment_set - set(outcome_variable.name)
-        assert all(
-            (v.name not in minimal_adjustment_set for v in causal_test_case.control_input_configuration)
-        ), "Treatment vars in adjustment set"
-        assert outcome_variable not in minimal_adjustment_set, "Outcome vars in adjustment set"
+
         variables_for_positivity = list(minimal_adjustment_set) + [treatment_variable.name] + [outcome_variable.name]
 
         if self._check_positivity_violation(variables_for_positivity):

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -88,9 +88,9 @@ class CausalTestEngine:
                 causal_test_results = []
 
                 for test in tests:
-                    treatment_variable = list(test.treatment_input_configuration.keys())[0]
-                    treatment_value = list(test.treatment_input_configuration.values())[0]
-                    control_value = list(test.control_input_configuration.values())[0]
+                    treatment_variable = test.treatment_variable
+                    treatment_value = test.treatment_value
+                    control_value = test.control_value
                     estimator = EstimatorClass(
                         (treatment_variable.name,),
                         treatment_value,

--- a/causal_testing/testing/causal_test_suite.py
+++ b/causal_testing/testing/causal_test_suite.py
@@ -13,8 +13,7 @@ class CausalTestSuite(UserDict):
     base_test_case's and execute each causal_test_case with each iterator.
     """
 
-    def add_test_object(self, base_test_case, causal_test_case_list, estimators_classes,
-                        estimate_type: str = "ate"):
+    def add_test_object(self, base_test_case, causal_test_case_list, estimators_classes, estimate_type: str = "ate"):
         """
         A setter object to allow for the easy construction of the dictionary test suite structure
 

--- a/causal_testing/testing/causal_test_suite.py
+++ b/causal_testing/testing/causal_test_suite.py
@@ -1,4 +1,8 @@
 from collections import UserDict
+from typing import Type, Iterable
+from causal_testing.testing.base_test_case import BaseTestCase
+from causal_testing.testing.causal_test_case import CausalTestCase
+from causal_testing.testing.estimators import Estimator
 
 
 class CausalTestSuite(UserDict):
@@ -13,7 +17,13 @@ class CausalTestSuite(UserDict):
     base_test_case's and execute each causal_test_case with each iterator.
     """
 
-    def add_test_object(self, base_test_case, causal_test_case_list, estimators_classes, estimate_type: str = "ate"):
+    def add_test_object(
+        self,
+        base_test_case: BaseTestCase,
+        causal_test_case_list: Iterable[CausalTestCase],
+        estimators_classes: Iterable[Type[Estimator]],
+        estimate_type: str = "ate",
+    ):
         """
         A setter object to allow for the easy construction of the dictionary test suite structure
 

--- a/causal_testing/testing/causal_test_suite.py
+++ b/causal_testing/testing/causal_test_suite.py
@@ -13,15 +13,16 @@ class CausalTestSuite(UserDict):
     base_test_case's and execute each causal_test_case with each iterator.
     """
 
-    def add_test_object(self, base_test_case, causal_test_case_list, estimators, estimate_type: str = "ate"):
+    def add_test_object(self, base_test_case, causal_test_case_list, estimators_classes,
+                        estimate_type: str = "ate"):
         """
         A setter object to allow for the easy construction of the dictionary test suite structure
 
         :param base_test_case: A BaseTestCase object consisting of a treatment variable, outcome variable and effect
         :param causal_test_case_list: A list of causal test cases to be executed
-        :param estimators: A list of estimators, the execute_test_suite function in the TestEngine will produce a list
+        :param estimators_classes: A list of estimator class references, the execute_test_suite function in the TestEngine will produce a list
                             of test results for each estimator
         :param estimate_type: A string which denotes the type of estimate to return
         """
-        test_object = {"tests": causal_test_case_list, "estimators": estimators, "estimate_type": estimate_type}
+        test_object = {"tests": causal_test_case_list, "estimators": estimators_classes, "estimate_type": estimate_type}
         self.data[base_test_case] = test_object

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -34,16 +34,16 @@ class Estimator(ABC):
     def __init__(
         self,
         treatment: tuple,
-        treatment_values: float,
-        control_values: float,
+        treatment_value: float,
+        control_value: float,
         adjustment_set: set,
         outcome: tuple,
         df: pd.DataFrame = None,
         effect_modifiers: dict[Variable:Any] = None,
     ):
         self.treatment = treatment
-        self.treatment_values = treatment_values
-        self.control_values = control_values
+        self.treatment_values = treatment_value
+        self.control_values = control_value
         self.adjustment_set = adjustment_set
         self.outcome = outcome
         self.df = df

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -42,8 +42,8 @@ class Estimator(ABC):
         effect_modifiers: dict[Variable:Any] = None,
     ):
         self.treatment = treatment
-        self.treatment_values = treatment_value
-        self.control_values = control_value
+        self.treatment_value = treatment_value
+        self.control_value = control_value
         self.adjustment_set = adjustment_set
         self.outcome = outcome
         self.df = df
@@ -90,15 +90,15 @@ class LogisticRegressionEstimator(Estimator):
     def __init__(
         self,
         treatment: tuple,
-        treatment_values: float,
-        control_values: float,
+        treatment_value: float,
+        control_value: float,
         adjustment_set: set,
         outcome: tuple,
         df: pd.DataFrame = None,
         effect_modifiers: dict[Variable:Any] = None,
         intercept: int = 1,
     ):
-        super().__init__(treatment, treatment_values, control_values, adjustment_set, outcome, df, effect_modifiers)
+        super().__init__(treatment, treatment_value, control_value, adjustment_set, outcome, df, effect_modifiers)
 
         for term in self.effect_modifiers:
             self.adjustment_set.add(term)
@@ -155,7 +155,7 @@ class LogisticRegressionEstimator(Estimator):
         self.model = model
 
         x = pd.DataFrame()
-        x[self.treatment[0]] = [self.treatment_values, self.control_values]
+        x[self.treatment[0]] = [self.treatment_value, self.control_value]
         x["Intercept"] = self.intercept
         for k, v in self.effect_modifiers.items():
             x[k] = v
@@ -212,8 +212,8 @@ class LinearRegressionEstimator(Estimator):
     def __init__(
         self,
         treatment: tuple,
-        treatment_values: float,
-        control_values: float,
+        treatment_value: float,
+        control_value: float,
         adjustment_set: set,
         outcome: tuple,
         df: pd.DataFrame = None,
@@ -221,7 +221,7 @@ class LinearRegressionEstimator(Estimator):
         product_terms: list[tuple[Variable, Variable]] = None,
         intercept: int = 1,
     ):
-        super().__init__(treatment, treatment_values, control_values, adjustment_set, outcome, df, effect_modifiers)
+        super().__init__(treatment, treatment_value, control_value, adjustment_set, outcome, df, effect_modifiers)
 
         if product_terms is None:
             product_terms = []
@@ -304,7 +304,7 @@ class LinearRegressionEstimator(Estimator):
         unit_effect = model.params[list(self.treatment)].values[0]  # Unit effect is the coefficient of the treatment
         [ci_low, ci_high] = self._get_confidence_intervals(model)
 
-        return unit_effect * self.treatment_values - unit_effect * self.control_values, [ci_low, ci_high]
+        return unit_effect * self.treatment_value - unit_effect * self.control_value, [ci_low, ci_high]
 
     def estimate_ate(self) -> tuple[float, list[float, float], float]:
         """Estimate the average treatment effect of the treatment on the outcome. That is, the change in outcome caused
@@ -315,8 +315,8 @@ class LinearRegressionEstimator(Estimator):
         model = self._run_linear_regression()
         # Create an empty individual for the control and treated
         individuals = pd.DataFrame(1, index=["control", "treated"], columns=model.params.index)
-        individuals.loc["control", list(self.treatment)] = self.control_values
-        individuals.loc["treated", list(self.treatment)] = self.treatment_values
+        individuals.loc["control", list(self.treatment)] = self.control_value
+        individuals.loc["treated", list(self.treatment)] = self.treatment_value
         # This is a temporary hack
         for t in self.square_terms:
             individuals[t + "^2"] = individuals[t] ** 2
@@ -338,7 +338,7 @@ class LinearRegressionEstimator(Estimator):
         self.model = model
 
         x = pd.DataFrame()
-        x[self.treatment[0]] = [self.treatment_values, self.control_values]
+        x[self.treatment[0]] = [self.treatment_value, self.control_value]
         x["Intercept"] = self.intercept
         for k, v in self.effect_modifiers.items():
             x[k] = v
@@ -389,7 +389,7 @@ class LinearRegressionEstimator(Estimator):
             self.effect_modifiers
         ), f"Must have at least one effect modifier to compute CATE - {self.effect_modifiers}."
         x = pd.DataFrame()
-        x[self.treatment[0]] = [self.treatment_values, self.control_values]
+        x[self.treatment[0]] = [self.treatment_value, self.control_value]
         x["Intercept"] = self.intercept
         for k, v in self.effect_modifiers.items():
             self.adjustment_set.add(k)
@@ -485,8 +485,8 @@ class CausalForestEstimator(Estimator):
         model.fit(outcome_df, treatment_df, X=effect_modifier_df, W=confounders_df)
 
         # Obtain the ATE and 95% confidence intervals
-        ate = model.ate(effect_modifier_df, T0=self.control_values, T1=self.treatment_values)
-        ate_interval = model.ate_interval(effect_modifier_df, T0=self.control_values, T1=self.treatment_values)
+        ate = model.ate(effect_modifier_df, T0=self.control_value, T1=self.treatment_value)
+        ate_interval = model.ate_interval(effect_modifier_df, T0=self.control_value, T1=self.treatment_value)
         ci_low, ci_high = ate_interval[0], ate_interval[1]
         return ate, [ci_low, ci_high]
 
@@ -525,9 +525,9 @@ class CausalForestEstimator(Estimator):
         model.fit(outcome_df, treatment_df, X=effect_modifier_df, W=confounders_df)
 
         # Obtain CATES and confidence intervals
-        conditional_ates = model.effect(effect_modifier_df, T0=self.control_values, T1=self.treatment_values).flatten()
+        conditional_ates = model.effect(effect_modifier_df, T0=self.control_value, T1=self.treatment_value).flatten()
         [ci_low, ci_high] = model.effect_interval(
-            effect_modifier_df, T0=self.control_values, T1=self.treatment_values, alpha=0.05
+            effect_modifier_df, T0=self.control_value, T1=self.treatment_value, alpha=0.05
         )
 
         # Merge results into a dataframe (CATE, confidence intervals, and effect modifier values)

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -282,7 +282,7 @@ class LinearRegressionEstimator(Estimator):
 
     def __init__(
         self,
-        treatment: tuple,    
+        treatment: tuple,
         treatment_value: float,
         control_value: float,
         adjustment_set: set,

--- a/examples/covasim_/doubling_beta/causal_test_beta.py
+++ b/examples/covasim_/doubling_beta/causal_test_beta.py
@@ -10,6 +10,7 @@ from causal_testing.testing.causal_test_case import CausalTestCase
 from causal_testing.testing.causal_test_outcome import Positive
 from causal_testing.testing.causal_test_engine import CausalTestEngine
 from causal_testing.testing.estimators import LinearRegressionEstimator
+from causal_testing.testing.base_test_case import BaseTestCase
 from matplotlib.pyplot import rcParams
 
 # Uncommenting the code below will make all graphs publication quality but requires a suitable latex installation
@@ -203,22 +204,26 @@ def engine_setup(observational_data_path):
     # 4. Construct a causal specification from the scenario and causal DAG
     causal_specification = CausalSpecification(scenario, causal_dag)
 
-    # 5. Create a causal test case
-    causal_test_case = CausalTestCase(control_input_configuration={beta: 0.016},
-                                      expected_causal_effect=Positive,
-                                      treatment_input_configuration={beta: 0.032},
-                                      outcome_variables={cum_infections})
+    # 5. Create a base test case
+    base_test_case = BaseTestCase(treatment_variable=beta,
+                                  outcome_variable=cum_infections)
 
-    # 6. Create a data collector
+    # 6. Create a causal test case
+    causal_test_case = CausalTestCase(base_test_case=base_test_case,
+                                      expected_causal_effect=Positive,
+                                      control_value=0.016,
+                                      treatment_value=0.032)
+
+    # 7. Create a data collector
     data_collector = ObservationalDataCollector(scenario, observational_data_path)
 
-    # 7. Create an instance of the causal test engine
+    # 8. Create an instance of the causal test engine
     causal_test_engine = CausalTestEngine(causal_specification, data_collector)
 
-    # 8. Obtain the minimal adjustment set for the causal test case from the causal DAG
-    causal_test_engine.identification(causal_test_case)
+    # 9. Obtain the minimal adjustment set for the base test case from the causal DAG
+    minimal_adjustment_set = causal_dag.identification(base_test_case)
 
-    return causal_test_engine.minimal_adjustment_set, causal_test_engine, causal_test_case
+    return minimal_adjustment_set, causal_test_engine, causal_test_case
 
 
 def plot_doubling_beta_CATEs(results_dict, title, figure=None, axes=None, row=None, col=None):

--- a/examples/covasim_/vaccinating_elderly/causal_test_vaccine.py
+++ b/examples/covasim_/vaccinating_elderly/causal_test_vaccine.py
@@ -11,6 +11,7 @@ from causal_testing.testing.causal_test_case import CausalTestCase
 from causal_testing.testing.causal_test_outcome import Positive, Negative, NoEffect
 from causal_testing.testing.causal_test_engine import CausalTestEngine
 from causal_testing.testing.estimators import LinearRegressionEstimator
+from causal_testing.testing.base_test_case import BaseTestCase
 
 
 def experimental_causal_test_vaccinate_elderly(runs_per_test_per_config: int = 30, verbose: bool = False):
@@ -71,21 +72,21 @@ def experimental_causal_test_vaccinate_elderly(runs_per_test_per_config: int = 3
 
     # 7. Create an instance of the causal test engine
     causal_test_engine = CausalTestEngine(causal_specification, data_collector, index_col=0)
+
     for outcome_variable, expected_effect in expected_outcome_effects.items():
-        causal_test_case = CausalTestCase(control_input_configuration={vaccine: 0},
+        base_test_case = BaseTestCase(treatment_variable=vaccine,
+                                      outcome_variable=outcome_variable)
+        causal_test_case = CausalTestCase(base_test_case=base_test_case,
                                           expected_causal_effect=expected_effect,
-                                          treatment_input_configuration={vaccine: 1},
-                                          outcome_variables={outcome_variable})
-
-
-
+                                          control_value=0,
+                                          treatment_value=1)
 
         # 8. Obtain the minimal adjustment set for the causal test case from the causal DAG
-        causal_test_engine.identification(causal_test_case)
+        minimal_adjustment_set = causal_dag.identification(base_test_case)
 
         # 9. Build statistical model
         linear_regression_estimator = LinearRegressionEstimator((vaccine.name,), 1, 0,
-                                                                causal_test_engine.minimal_adjustment_set,
+                                                                minimal_adjustment_set,
                                                                 (outcome_variable.name,))
 
         # 10. Execute test and save results in dict

--- a/examples/lr91/causal_test_max_conductances_test_suite.py
+++ b/examples/lr91/causal_test_max_conductances_test_suite.py
@@ -72,20 +72,19 @@ def causal_testing_sensitivity_analysis():
         for treatment_value in treatment_values:
             test_list.append(CausalTestCase(base_test_case, oracle, control_value, treatment_value))
         test_suite.add_test_object(base_test_case=base_test_case,
-                                   test_list=test_list,
-                                   estimators=estimator_list,
+                                   causal_test_case_list=test_list,
+                                   estimators_classes=estimator_list,
                                    estimate_type='ate')
 
     causal_test_results = effects_on_APD90(OBSERVATIONAL_DATA_PATH, test_suite)
 
     # Extract data from causal_test_results needed for plotting
     for base_test_case in causal_test_results:
-
         # Place results of test_suite into format required for plotting
         results[base_test_case.treatment_variable.name] = \
             {"ate": [result.ate for result in causal_test_results[base_test_case]['LinearRegressionEstimator']],
              "cis": [result.confidence_intervals for result in
-                     causal_test_results[base_test_case][0]]}
+                     causal_test_results[base_test_case]['LinearRegressionEstimator']]}
 
     plot_ates_with_cis(results, treatment_values)
 

--- a/tests/testing_tests/test_causal_test_case.py
+++ b/tests/testing_tests/test_causal_test_case.py
@@ -43,17 +43,17 @@ class TestCausalTestEngineObservational(unittest.TestCase):
             treatment_value=1,
         )
 
-    def test_get_treatment_variables(self):
-        self.assertEqual(self.causal_test_case.get_treatment_variables(), ["A"])
+    def test_get_treatment_variable(self):
+        self.assertEqual(self.causal_test_case.get_treatment_variable(), "A")
 
-    def test_get_outcome_variables(self):
-        self.assertEqual(self.causal_test_case.get_outcome_variables(), ["C"])
+    def test_get_outcome_variable(self):
+        self.assertEqual(self.causal_test_case.get_outcome_variable(), "C")
 
-    def test_get_treatment_values(self):
-        self.assertEqual(self.causal_test_case.get_treatment_values(), [1])
+    def test_get_treatment_value(self):
+        self.assertEqual(self.causal_test_case.get_treatment_value(), 1)
 
-    def test_get_control_values(self):
-        self.assertEqual(self.causal_test_case.get_control_values(), [0])
+    def test_get_control_value(self):
+        self.assertEqual(self.causal_test_case.get_control_value(), 0)
 
     def test_str(self):
         self.assertEqual(

--- a/tests/testing_tests/test_causal_test_suite.py
+++ b/tests/testing_tests/test_causal_test_suite.py
@@ -62,7 +62,7 @@ class TestCausalTestSuite(unittest.TestCase):
         # 3. Create test_suite and add a test
         self.test_suite = CausalTestSuite()
         self.test_suite.add_test_object(
-            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators=self.estimators
+            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators_classes=self.estimators
         )
 
     def test_adding_test_object(self):
@@ -71,7 +71,7 @@ class TestCausalTestSuite(unittest.TestCase):
         test_list = [CausalTestCase(self.base_test_case, self.expected_causal_effect, 0, 1)]
         estimators = [LinearRegressionEstimator]
         test_suite.add_test_object(
-            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators=estimators
+            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators_classes=estimators
         )
         manual_test_object = {
             self.base_test_case: {"tests": test_list, "estimators": estimators, "estimate_type": "ate"}
@@ -85,7 +85,7 @@ class TestCausalTestSuite(unittest.TestCase):
         test_list = [CausalTestCase(self.base_test_case, self.expected_causal_effect, 0, 1)]
         estimators = [LinearRegressionEstimator]
         self.test_suite.add_test_object(
-            base_test_case=base_test_case, causal_test_case_list=test_list, estimators=estimators
+            base_test_case=base_test_case, causal_test_case_list=test_list, estimators_classes=estimators
         )
 
         manual_test_case = {"tests": test_list, "estimators": estimators, "estimate_type": "ate"}
@@ -110,7 +110,7 @@ class TestCausalTestSuite(unittest.TestCase):
         test_suite_2_estimators = CausalTestSuite()
         test_list = [CausalTestCase(self.base_test_case, self.expected_causal_effect, 0, 1)]
         test_suite_2_estimators.add_test_object(
-            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators=estimators
+            base_test_case=self.base_test_case, causal_test_case_list=test_list, estimators_classes=estimators
         )
         causal_test_engine = self.create_causal_test_engine()
         causal_test_results = causal_test_engine.execute_test_suite(test_suite=test_suite_2_estimators)


### PR DESCRIPTION
This PR should simplify the structure of the CausalTestCase by assuming that there will only be a single treatment and control value per test case. 