### PR TITLE
install instructions for specific versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Here are some explanations for the causal inference terminology used above.
 
 ## Installation
 
-To use the causal testing framework, clone the repository, `cd` into the root directory, and run `pip install -e .`. More detailled installation instructions can be found in the [online documentation](https://causal-testing-framework.readthedocs.io/en/latest/installation.html).
+See the readthedocs site for installation instructions](https://causal-testing-framework.readthedocs.io/en/latest/installation.html).
 
 ## Usage
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,10 +20,31 @@ Alternatively, on Linux systems, this can be done with `sudo apt install graphvi
 
 Install from source
 -------------------
+
+In future it will be possible to install from PyPI, but for now...
+
 .. code-block:: console
 
     git clone https://github.com/CITCOM-project/CausalTestingFramework
     cd CausalTestingFramework
+
+then, to install a specific release:
+
+.. code-block:: console    
+    git fetch --all --tags --prune
+    git checkout tags/<tag> -b <branch>
+    pip install -e .
+
+e.g. version `1.0.0`
+
+.. code-block:: console    
+    git fetch --all --tags --prune
+    git checkout tags/1.0.0 -b version
+    pip install -e .
+
+or to install the latest development version:
+
+.. code-block:: console    
     pip install -e .
 
 Use 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ readme = open("README.md", encoding = "UTF-8").read()
 
 setup(
     name="causal_testing_framework",
-    version="0.0.1",
+    version="1.0.0",
     description="A framework for causal testing using causal directed acyclic graphs.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Draft 1.0.0 release here https://github.com/CITCOM-project/CausalTestingFramework/releases/edit/untagged-09a6985599a8f8f7aa2d should generate `zip` and `tar.gz` on publish. We would still expect people to install from github clone rather than these files. Instructions for this are in this PR. They're too clunky so we need to get on PyPI soon.