### PR TITLE
Update docs - Code block rendering

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,35 +21,28 @@ Alternatively, on Linux systems, this can be done with `sudo apt install graphvi
 Install from source
 -------------------
 
-In future it will be possible to install from PyPI, but for now...
-
-.. code-block:: console
+In future it will be possible to install from PyPI, but for now::
 
     git clone https://github.com/CITCOM-project/CausalTestingFramework
     cd CausalTestingFramework
 
-then, to install a specific release:
+then, to install a specific release::
 
-.. code-block:: console    
     git fetch --all --tags --prune
     git checkout tags/<tag> -b <branch>
     pip install -e .
 
-e.g. version `1.0.0`
+e.g. version `1.0.0`::
 
-.. code-block:: console    
     git fetch --all --tags --prune
     git checkout tags/1.0.0 -b version
     pip install -e .
 
-or to install the latest development version:
+or to install the latest development version::
 
-.. code-block:: console    
     pip install -e .
 
-Use 
-
-.. code-block:: console
+Use::
 
     pip install -e .[dev]
 

--- a/docs/source/json_front_end.rst
+++ b/docs/source/json_front_end.rst
@@ -33,23 +33,17 @@ Each test requires:
 
 Run Commands
 ------------
-To run the JSON frontend example from the root directory of the project, use
-
-.. code-block:: console
+To run the JSON frontend example from the root directory of the project, use::
 
     python examples/poisson/run_causal_tests.py
 
-A failure flag `-f` can be specified to stop the framework running if a test is failed
-
-.. code-block:: console
+A failure flag `-f` can be specified to stop the framework running if a test is failed::
 
     python examples/poisson/run_causal_tests.py -f
 
 There are two main outputs of this frontend, both are controlled by the logging module. Firstly outputs are printed to stdout (terminal).
 Secondly a log file is produced, by default a file called `json_frontend.log` is produced in the directory the script is called from.
 
-The behaviour of where the log file is produced and named can be altered with the --log_path argument:
-
-.. code-block:: console
+The behaviour of where the log file is produced and named can be altered with the --log_path argument::
 
     python examples\poisson\run_causal_tests.py -f --data_path="examples\poisson\data.csv" --dag_path="examples\poisson\dag.dot" --json_path="examples\poisson\causal_tests.json --log_path="example_directory\logname.log"


### PR DESCRIPTION
Fix rendering of code blocks by updating formatting (adding a space between codeblock definition and contents) and changing the codeblocks from consoles:

`.. code-block:: console`

to literals:

`:: `