### PR TITLE
Product terms now accessible in LR estimator

### DIFF
--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -300,7 +300,7 @@ class LinearRegressionEstimator(Estimator):
         self.intercept = intercept
 
         if product_terms:
-            for (term_a, term_b) in product_terms:
+            for term_a, term_b in product_terms:
                 self.add_product_term_to_df(term_a, term_b)
         for term in self.effect_modifiers:
             self.adjustment_set.add(term)

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -294,17 +294,16 @@ class LinearRegressionEstimator(Estimator):
     ):
         super().__init__(treatment, treatment_value, control_value, adjustment_set, outcome, df, effect_modifiers)
 
-        if product_terms is None:
-            product_terms = []
-        for (term_a, term_b) in product_terms:
-            self.add_product_term_to_df(term_a, term_b)
-        for term in self.effect_modifiers:
-            self.adjustment_set.add(term)
-
-        self.product_terms = product_terms
+        self.product_terms = []
         self.square_terms = []
         self.inverse_terms = []
         self.intercept = intercept
+
+        if product_terms:
+            for (term_a, term_b) in product_terms:
+                self.add_product_term_to_df(term_a, term_b)
+        for term in self.effect_modifiers:
+            self.adjustment_set.add(term)
 
     def add_modelling_assumptions(self):
         """

--- a/tests/testing_tests/test_estimators.py
+++ b/tests/testing_tests/test_estimators.py
@@ -331,3 +331,25 @@ class TestCausalForestEstimator(unittest.TestCase):
         )
         cates_df, _ = causal_forest.estimate_cates()
         self.assertGreater(cates_df["cate"].mean(), 0)
+
+
+class TestLinearRegressionInteraction(unittest.TestCase):
+    """Test linear regression for estimating effects involving interaction."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Y = 2X1 - 3X2 + 2*X1*X2 + 10
+        df = pd.DataFrame({'X1': np.random.uniform(-1000, 1000, 1000),
+                           'X2': np.random.uniform(-1000, 1000, 1000)})
+        df['Y'] = 2*df['X1'] - 3*df['X2'] + 2*df['X1']*df['X2'] + 10
+        cls.df = df
+        print(df)
+
+    def test_X1_effect(self):
+        """When we fix the value of X2 to 0, the effect of X1 on Y should become ~2 (because X2 terms are cancelled)."""
+        x2 = Input('X2', float)
+        lr_model = LinearRegressionEstimator(('X1',), 1, 0, {'X2'}, ('Y',), effect_modifiers={x2: 0},
+                                             product_terms=[('X1', 'X2')], df=self.df)
+        test_results = lr_model.estimate_ate()
+        ate = test_results[0]
+        self.assertAlmostEqual(ate, 2.0)

--- a/tests/testing_tests/test_estimators.py
+++ b/tests/testing_tests/test_estimators.py
@@ -339,17 +339,17 @@ class TestLinearRegressionInteraction(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         # Y = 2X1 - 3X2 + 2*X1*X2 + 10
-        df = pd.DataFrame({'X1': np.random.uniform(-1000, 1000, 1000),
-                           'X2': np.random.uniform(-1000, 1000, 1000)})
-        df['Y'] = 2*df['X1'] - 3*df['X2'] + 2*df['X1']*df['X2'] + 10
+        df = pd.DataFrame({"X1": np.random.uniform(-1000, 1000, 1000), "X2": np.random.uniform(-1000, 1000, 1000)})
+        df["Y"] = 2 * df["X1"] - 3 * df["X2"] + 2 * df["X1"] * df["X2"] + 10
         cls.df = df
         print(df)
 
     def test_X1_effect(self):
         """When we fix the value of X2 to 0, the effect of X1 on Y should become ~2 (because X2 terms are cancelled)."""
-        x2 = Input('X2', float)
-        lr_model = LinearRegressionEstimator(('X1',), 1, 0, {'X2'}, ('Y',), effect_modifiers={x2: 0},
-                                             product_terms=[('X1', 'X2')], df=self.df)
+        x2 = Input("X2", float)
+        lr_model = LinearRegressionEstimator(
+            ("X1",), 1, 0, {"X2"}, ("Y",), effect_modifiers={x2: 0}, product_terms=[("X1", "X2")], df=self.df
+        )
         test_results = lr_model.estimate_ate()
         ate = test_results[0]
         self.assertAlmostEqual(ate, 2.0)


### PR DESCRIPTION
In this PR, I have made a minor change to the init method of the `LinearRegressionEstimator` class to ensure that `self.product_terms` is created before `self.add_product_term_to_df` is called.

Previously the initialiser was calling the method `self.add_product_term_to_df`(which adds pairs of variables to the `self.product_terms` list) before `self.product_terms` is created.

I have also added a test for a simple causal effect with an interaction. This test failed due to this bug and now passes after the fix.

