### PR TITLE
Fix PyPI github action

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -22,6 +22,7 @@ jobs:
           pip3 install .
           pip3 install .[pypi]
           pip3 install build
+          pip3 install setuptools_scm
       - name: Build Package
         run: |
           python -m build --no-isolation


### PR DESCRIPTION
The action failed due to 
```
ERROR Missing dependencies:
	setuptools_scm[toml]>=6.2
Error: Process completed with exit code 1.
```
So I've added an instruction to install `setuptools_scm` and tested it on a new local environment.
