### PR TITLE
Fix pyproject.toml module discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=64",
     "setuptools_scm[toml]>=6.2",
     "wheel"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ build-backend = "setuptools.build_meta"
         Documentation = "https://causal-testing-framework.readthedocs.io/"
         Source = "https://github.com/CITCOM-project/CausalTestingFramework"
 
-[tool.setuptools.packages.find]
-where = ["causal_testing"]
+[tool.setuptools.packages]
+find = {}
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Previously a single module was specified, however this setup assumes a flat project structure with single module. For a more complex project structure auto discover works better: 
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

This fixed the editable install problems