### PR TITLE
Py pi action setuptool version

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,5 +1,9 @@
 name: Publish python PyPI
 
+on:
+  push:
+    tags:
+      - v0.0.0
 jobs:
   build-release:
     name: Build and publish PyPI

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -22,6 +22,7 @@ jobs:
           pip3 install .
           pip3 install .[pypi]
           pip3 install build
+          pip3 install setuptools>=64
           pip3 install setuptools_scm
       - name: Build Package
         run: |


### PR DESCRIPTION
Currently the `Publish python PyPI test` action is hitting the error:

```
ERROR Missing dependencies:
	setuptools>=64
```

The version installed is 
`Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages (from numba->shap<0.41.0,>=0.38.1->econml~=0.12->causal-testing-framework==2.0.3) (58.1.0)`

