### PR TITLE
upgrade setuptools version

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -22,7 +22,7 @@ jobs:
           pip3 install .
           pip3 install .[pypi]
           pip3 install build
-          pip3 install setuptools>=64
+          pip3 install setuptools --upgrade
           pip3 install setuptools_scm
       - name: Build Package
         run: |


### PR DESCRIPTION
The PyPI GH action is still has the problem of setuptools not being the correct version.

Not sure why the setuptools version isn't upgrading with the command `pip install setuptools>=64` when it works well locally. 

I see 2 potential fixes. Firstly calling `pip install setuptools --upgrade` which is what this PR does. Or uninstalling setuptools explicitly then installing the pinned version 64 `pip install setuptools>=64`.

