### PR TITLE
Json read multiple files

### DIFF
--- a/causal_testing/data_collection/data_collector.py
+++ b/causal_testing/data_collection/data_collector.py
@@ -124,9 +124,9 @@ class ExperimentalDataCollector(DataCollector):
 class ObservationalDataCollector(DataCollector):
     """A data collector that extracts data that is relevant to the specified scenario from a csv of execution data."""
 
-    def __init__(self, scenario: Scenario, csv_path: str):
+    def __init__(self, scenario: Scenario, data: pd.DataFrame):
         super().__init__(scenario)
-        self.csv_path = csv_path
+        self.data = data
 
     def collect_data(self, **kwargs) -> pd.DataFrame:
         """Read a csv containing execution data for the system-under-test into a pandas dataframe and filter to remove
@@ -137,7 +137,7 @@ class ObservationalDataCollector(DataCollector):
         :return: A pandas dataframe containing execution data that is valid for the scenario-under-test.
         """
 
-        execution_data_df = pd.read_csv(self.csv_path, **kwargs)
+        execution_data_df = self.data
         for meta in self.scenario.metas():
             meta.populate(execution_data_df)
         scenario_execution_data_df = self.filter_valid_data(execution_data_df)

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -133,7 +133,6 @@ class JsonUtility(ABC):
         """Parse a JSON input file into inputs, outputs, metas and a test plan"""
         with open(self.paths.json_path, encoding="utf-8") as f:
             self.test_plan = json.load(f)
-            breakpoint()
         for data_file in self.paths.data_paths:
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -133,6 +133,7 @@ class JsonUtility(ABC):
         """Parse a JSON input file into inputs, outputs, metas and a test plan"""
         with open(self.paths.json_path, encoding="utf-8") as f:
             self.test_plan = json.load(f)
+            breakpoint()
         for data_file in self.paths.data_paths:
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)
@@ -286,7 +287,7 @@ class JsonClassPaths:
     def __init__(self, json_path: str, dag_path: str, data_paths: str):
         self.json_path = Path(json_path)
         self.dag_path = Path(dag_path)
-        self.data_paths = [Path(path) for path in data_paths]
+        self.data_paths = [Path(path) for path in [data_paths]]
 
 
 @dataclass()

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -137,7 +137,6 @@ class JsonUtility(ABC):
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)
         self.data = pd.concat(self.data)
-        breakpoint()
     def _populate_metas(self):
         """
         Populate data with meta-variable values and add distributions to Causal Testing Framework Variables
@@ -198,7 +197,6 @@ class JsonUtility(ABC):
 
         with tempfile.TemporaryFile(delete=False) as temp:
             self.data.to_csv(temp)
-            breakpoint()
             data_collector = ObservationalDataCollector(self.modelling_scenario, temp.name)
             causal_test_engine = CausalTestEngine(self.causal_specification, data_collector, index_col=0)
 

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -137,6 +137,7 @@ class JsonUtility(ABC):
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)
         self.data = pd.concat(self.data)
+
     def _populate_metas(self):
         """
         Populate data with meta-variable values and add distributions to Causal Testing Framework Variables
@@ -286,7 +287,7 @@ class JsonClassPaths:
     def __init__(self, json_path: str, dag_path: str, data_paths: str):
         self.json_path = Path(json_path)
         self.dag_path = Path(dag_path)
-        self.data_paths = [Path(path) for path in [data_paths]]
+        self.data_paths = [Path(path) for path in data_paths]
 
 
 @dataclass()

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -4,6 +4,7 @@ https://causal-testing-framework.readthedocs.io/en/latest/json_front_end.html"""
 import argparse
 import json
 import logging
+import tempfile
 
 from abc import ABC
 from dataclasses import dataclass
@@ -46,20 +47,20 @@ class JsonUtility(ABC):
     def __init__(self, log_path):
         self.paths = None
         self.variables = None
-        self.data = None
+        self.data = list()
         self.test_plan = None
         self.modelling_scenario = None
         self.causal_specification = None
         self.setup_logger(log_path)
 
-    def set_paths(self, json_path: str, dag_path: str, data_path: str):
+    def set_paths(self, json_path: str, dag_path: str, data_paths: str):
         """
         Takes a path of the directory containing all scenario specific files and creates individual paths for each file
         :param json_path: string path representation to .json file containing test specifications
         :param dag_path: string path representation to the .dot file containing the Causal DAG
         :param data_path: string path representation to the data file
         """
-        self.paths = JsonClassPaths(json_path=json_path, dag_path=dag_path, data_path=data_path)
+        self.paths = JsonClassPaths(json_path=json_path, dag_path=dag_path, data_paths=data_paths)
 
     def set_variables(self, inputs: list[dict], outputs: list[dict], metas: list[dict]):
         """Populate the Causal Variables
@@ -132,8 +133,9 @@ class JsonUtility(ABC):
         """Parse a JSON input file into inputs, outputs, metas and a test plan"""
         with open(self.paths.json_path, encoding="utf-8") as f:
             self.test_plan = json.load(f)
-
-        self.data = pd.read_csv(self.paths.data_path)
+        for data_file in self.paths.data_paths:
+            df = pd.read_csv(data_file, header=0)
+            self.data.append(df)
 
     def _populate_metas(self):
         """
@@ -252,6 +254,7 @@ class JsonUtility(ABC):
             "--data_path",
             help="Specify path to file containing runtime data",
             required=True,
+            nargs='+',
         )
         parser.add_argument(
             "--dag_path",
@@ -282,7 +285,7 @@ class JsonClassPaths:
     def __init__(self, json_path: str, dag_path: str, data_path: str):
         self.json_path = Path(json_path)
         self.dag_path = Path(dag_path)
-        self.data_path = Path(data_path)
+        self.data_paths = [Path(path) for path in data_path]
 
 
 @dataclass()

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -4,7 +4,6 @@ https://causal-testing-framework.readthedocs.io/en/latest/json_front_end.html"""
 import argparse
 import json
 import logging
-import tempfile
 
 from abc import ABC
 from dataclasses import dataclass
@@ -47,7 +46,7 @@ class JsonUtility(ABC):
     def __init__(self, log_path):
         self.paths = None
         self.variables = None
-        self.data = list()
+        self.data = []
         self.test_plan = None
         self.modelling_scenario = None
         self.causal_specification = None
@@ -256,7 +255,7 @@ class JsonUtility(ABC):
             "--data_path",
             help="Specify path to file containing runtime data",
             required=True,
-            nargs='+',
+            nargs="+",
         )
         parser.add_argument(
             "--dag_path",

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -195,10 +195,8 @@ class JsonUtility(ABC):
                 - estimation_model - Estimator instance for the test being run
         """
 
-        with tempfile.TemporaryFile(delete=False) as temp:
-            self.data.to_csv(temp)
-            data_collector = ObservationalDataCollector(self.modelling_scenario, temp.name)
-            causal_test_engine = CausalTestEngine(self.causal_specification, data_collector, index_col=0)
+        data_collector = ObservationalDataCollector(self.modelling_scenario, self.data)
+        causal_test_engine = CausalTestEngine(self.causal_specification, data_collector, index_col=0)
 
         minimal_adjustment_set = self.causal_specification.causal_dag.identification(causal_test_case.base_test_case)
         treatment_var = causal_test_case.treatment_variable

--- a/tests/data_collection_tests/test_observational_data_collector.py
+++ b/tests/data_collection_tests/test_observational_data_collector.py
@@ -38,18 +38,18 @@ class TestObservationalDataCollector(unittest.TestCase):
 
     def test_not_all_variables_in_data(self):
         scenario = Scenario({self.X1, self.X2, self.X3, self.X4})
-        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df_path)
+        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df)
         self.assertRaises(IndexError, observational_data_collector.collect_data)
 
     def test_all_variables_in_data(self):
         scenario = Scenario({self.X1, self.X2, self.X3, self.Y1, self.Y2})
-        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df_path)
+        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df)
         df = observational_data_collector.collect_data(index_col=0)
         assert df.equals(self.observational_df), f"\n{df}\nwas not equal to\n{self.observational_df}"
 
     def test_data_constraints(self):
         scenario = Scenario({self.X1, self.X2, self.X3, self.Y1, self.Y2}, {self.X1.z3 > 2})
-        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df_path)
+        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df)
         df = observational_data_collector.collect_data(index_col=0)
         expected = self.observational_df.loc[[2, 3]]
         assert df.equals(expected), f"\n{df}\nwas not equal to\n{expected}"
@@ -60,7 +60,7 @@ class TestObservationalDataCollector(unittest.TestCase):
 
         meta = Meta("M", int, populate_m)
         scenario = Scenario({self.X1, meta})
-        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df_path)
+        observational_data_collector = ObservationalDataCollector(scenario, self.observational_df)
         data = observational_data_collector.collect_data()
         assert all((m == 2 * x1 for x1, m in zip(data["X1"], data["M"])))
 

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -26,9 +26,9 @@ class TestJsonClass(unittest.TestCase):
         dag_file_name = "dag.dot"
         data_file_name = "data.csv"
         test_data_dir_path = Path("tests/resources/data")
-        self.json_path = test_data_dir_path / json_file_name
-        self.dag_path = test_data_dir_path / dag_file_name
-        self.data_path = test_data_dir_path / data_file_name
+        self.json_path = str(test_data_dir_path / json_file_name)
+        self.dag_path = str(test_data_dir_path / dag_file_name)
+        self.data_path = str(test_data_dir_path / data_file_name)
         self.json_class = JsonUtility("logs.log")
         self.example_distribution = scipy.stats.uniform(1, 10)
         self.input_dict_list = [{"name": "test_input", "type": float, "distribution": self.example_distribution}]

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -28,7 +28,7 @@ class TestJsonClass(unittest.TestCase):
         test_data_dir_path = Path("tests/resources/data")
         self.json_path = str(test_data_dir_path / json_file_name)
         self.dag_path = str(test_data_dir_path / dag_file_name)
-        self.data_path = str(test_data_dir_path / data_file_name)
+        self.data_path = [str(test_data_dir_path / data_file_name)]
         self.json_class = JsonUtility("logs.log")
         self.example_distribution = scipy.stats.uniform(1, 10)
         self.input_dict_list = [{"name": "test_input", "type": float, "distribution": self.example_distribution}]
@@ -40,7 +40,7 @@ class TestJsonClass(unittest.TestCase):
     def test_setting_paths(self):
         self.assertEqual(self.json_class.paths.json_path, Path(self.json_path))
         self.assertEqual(self.json_class.paths.dag_path, Path(self.dag_path))
-        self.assertEqual(self.json_class.paths.data_path, Path(self.data_path))
+        self.assertEqual(self.json_class.paths.data_paths, [Path(self.data_path[0])]) # Needs to be list of Paths
 
     def test_set_inputs(self):
         ctf_input = [Input("test_input", float, self.example_distribution)]
@@ -61,7 +61,7 @@ class TestJsonClass(unittest.TestCase):
 
     def test_argparse(self):
         args = self.json_class.get_args(["--data_path=data.csv", "--dag_path=dag.dot", "--json_path=tests.json"])
-        self.assertEqual(args.data_path, "data.csv")
+        self.assertEqual(args.data_path, ["data.csv"])
         self.assertEqual(args.dag_path, "dag.dot")
         self.assertEqual(args.json_path, "tests.json")
 

--- a/tests/testing_tests/test_causal_test_engine.py
+++ b/tests/testing_tests/test_causal_test_engine.py
@@ -59,7 +59,7 @@ class TestCausalTestEngineObservational(unittest.TestCase):
 
         # 5. Create observational data collector
         # Obsolete?
-        self.data_collector = ObservationalDataCollector(self.scenario, self.observational_data_csv_path)
+        self.data_collector = ObservationalDataCollector(self.scenario, df)
 
         # 5. Create causal test engine
         self.causal_test_engine = CausalTestEngine(self.causal_specification, self.data_collector)

--- a/tests/testing_tests/test_causal_test_suite.py
+++ b/tests/testing_tests/test_causal_test_suite.py
@@ -40,9 +40,7 @@ class TestCausalTestSuite(unittest.TestCase):
         df = pd.DataFrame({"D": list(np.random.normal(60, 10, 1000))})  # D = exogenous
         df["A"] = [1 if d > 50 else 0 for d in df["D"]]
         df["C"] = df["D"] + (4 * (df["A"] + 2))  # C = (4*(A+2)) + D
-        self.observational_data_csv_path = os.path.join(temp_dir_path, "observational_data.csv")
-        df.to_csv(self.observational_data_csv_path, index=False)
-
+        self.df = df
         self.causal_dag = CausalDAG(dag_dot_path)
 
         # 3. Specify data structures required for test suite
@@ -126,6 +124,6 @@ class TestCausalTestSuite(unittest.TestCase):
         """
         causal_specification = CausalSpecification(self.scenario, self.causal_dag)
 
-        data_collector = ObservationalDataCollector(self.scenario, self.observational_data_csv_path)
+        data_collector = ObservationalDataCollector(self.scenario, self.df)
         causal_test_engine = CausalTestEngine(causal_specification, data_collector)
         return causal_test_engine


### PR DESCRIPTION
Allows for multiple CSVs to be specified with the Json Frontend, which will concatenate them assuming the same columns are in each CSV. 

`python foo.py --data_path "data/bar1.csv" "data/bar2.csv" --dag_path="data/bar.dot" --json_path="data/bar.json"