### PR TITLE
Json arg parser

### DIFF
--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -89,13 +89,12 @@ class JsonUtility:
         )
         return abstract_test
 
-    def generate_tests(self, effects: dict, mutates: dict, estimators: dict, f_flag: bool):
+    def generate_tests(self, effects: dict, mutates: dict, estimators: dict):
         """Runs and evaluates each test case specified in the JSON input
 
         :param effects: Dictionary mapping effect class instances to string representations.
         :param mutates: Dictionary mapping mutation functions to string representations.
         :param estimators: Dictionary mapping estimator classes to string representations.
-        :param f_flag: Failure flag that if True the script will stop executing when a test fails.
         """
         failures = 0
         for test in self.test_plan["tests"]:
@@ -108,7 +107,7 @@ class JsonUtility:
             logger.info(abstract_test)
             logger.info([abstract_test.treatment_variable.name, abstract_test.treatment_variable.distribution])
             logger.info("Number of concrete tests for test case: %s", str(len(concrete_tests)))
-            failures = self._execute_tests(concrete_tests, estimators, test, f_flag)
+            failures = self._execute_tests(concrete_tests, estimators, test, self.args.f_flag)
             logger.info("%s/%s failed for %s\n", failures, len(concrete_tests), test["name"])
 
     def _execute_tests(self, concrete_tests, estimators, test, f_flag):

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -52,12 +52,14 @@ class JsonUtility:
         self.args = self.get_args()
         self.setup_logger(self.args.log_path)
         self._set_paths()
+
     def _set_paths(self):
         """
         Takes a path of the directory containing all scenario specific files and creates individual paths for each file
         """
-        self.paths = JsonClassPaths(json_path=self.args.json_path, dag_path=self.args.json_path,
-                                    data_paths=self.args.json_path)
+        self.paths = JsonClassPaths(
+            json_path=self.args.json_path, dag_path=self.args.dag_path, data_paths=self.args.data_path
+        )
 
     def setup(self, scenario: Scenario):
         """Function to populate all the necessary parts of the json_class needed to execute tests"""

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -42,23 +42,22 @@ class JsonUtility:
     :attr {CausalSpecification} causal_specification:
     """
 
-    def __init__(self, log_path):
+    def __init__(self):
         self.paths = None
         self.variables = None
         self.data = []
         self.test_plan = None
         self.scenario = None
         self.causal_specification = None
-        self.setup_logger(log_path)
-
-    def set_paths(self, json_path: str, dag_path: str, data_paths: str):
+        self.args = self.get_args()
+        self.setup_logger(self.args.log_path)
+        self._set_paths()
+    def _set_paths(self):
         """
         Takes a path of the directory containing all scenario specific files and creates individual paths for each file
-        :param json_path: string path representation to .json file containing test specifications
-        :param dag_path: string path representation to the .dot file containing the Causal DAG
-        :param data_paths: string path representation to the data files
         """
-        self.paths = JsonClassPaths(json_path=json_path, dag_path=dag_path, data_paths=data_paths)
+        self.paths = JsonClassPaths(json_path=self.args.json_path, dag_path=self.args.json_path,
+                                    data_paths=self.args.json_path)
 
     def setup(self, scenario: Scenario):
         """Function to populate all the necessary parts of the json_class needed to execute tests"""

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -158,7 +158,7 @@ class LogisticRegressionEstimator(Estimator):
         model = smf.logit(formula=self.formula, data=data).fit(disp=0)
         return model
 
-    def estimate(self, data: pd.DataFrame, adjustment_config:dict = None) -> RegressionResultsWrapper:
+    def estimate(self, data: pd.DataFrame, adjustment_config: dict = None) -> RegressionResultsWrapper:
         """add terms to the dataframe and estimate the outcome from the data
         :param data: A pandas dataframe containing execution data from the system-under-test.
         :param adjustment_config: Dictionary containing the adjustment configuration of the adjustment set

--- a/examples/poisson/example_run_causal_tests.py
+++ b/examples/poisson/example_run_causal_tests.py
@@ -179,11 +179,7 @@ def test_run_causal_tests():
 
 if __name__ == "__main__":
     args = MyJsonUtility.get_args()
-    json_utility = MyJsonUtility(args.log_path)  # Create an instance of the extended JsonUtility class
-    json_utility.set_paths(
-        args.json_path, args.dag_path, args.data_path
-    )  # Set the path to the data.csv, dag.dot and causal_tests.json file
-
+    json_utility = MyJsonUtility()  # Create an instance of the extended JsonUtility class
     # Load the Causal Variables into the JsonUtility class ready to be used in the tests
     json_utility.setup(scenario=modelling_scenario)  # Sets up all the necessary parts of the json_class needed to execute tests
 

--- a/examples/poisson/example_run_causal_tests.py
+++ b/examples/poisson/example_run_causal_tests.py
@@ -183,4 +183,4 @@ if __name__ == "__main__":
     # Load the Causal Variables into the JsonUtility class ready to be used in the tests
     json_utility.setup(scenario=modelling_scenario)  # Sets up all the necessary parts of the json_class needed to execute tests
 
-    json_utility.generate_tests(effects, mutates, estimators, args.f)
+    json_utility.generate_tests(effects, mutates, estimators)


### PR DESCRIPTION
Small PR for something I thought of whilst working on other bits of the JSON front end. 

Looking at the poisson json example, it seems a bit awkward to have the user handling the argparsing outputs:

```
if __name__ == "__main__":
    args = MyJsonUtility.get_args()
    json_utility = MyJsonUtility(args.log_path)  # Create an instance of the extended JsonUtility class
    json_utility.set_paths(
        args.json_path, args.dag_path, args.data_path
    )  # Set the path to the data.csv, dag.dot and causal_tests.json file

    # Load the Causal Variables into the JsonUtility class ready to be used in the tests
    json_utility.setup(scenario=modelling_scenario)  # Sets up all the necessary parts of the json_class needed to execute tests

    json_utility.generate_tests(effects, mutates, estimators, args.f)
```

Moving the arg parsing calls into the class we can simplify this to:

```
if __name__ == "__main__":
    args = MyJsonUtility.get_args()
    json_utility = MyJsonUtility()  # Create an instance of the extended JsonUtility class
    # Load the Causal Variables into the JsonUtility class ready to be used in the tests
    json_utility.setup(scenario=modelling_scenario)  # Sets up all the necessary parts of the json_class needed to execute tests

    json_utility.generate_tests(effects, mutates, estimators)
```

A potential downside to this is that it will be harder to use the class without using the command line (i.e. calling it from another script). However as this is a frontend and not a code based entry point I personally don't take issue with this?
