### PR TITLE
Json output to file

### DIFF
--- a/causal_testing/__init__.py
+++ b/causal_testing/__init__.py
@@ -12,4 +12,3 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -177,7 +177,8 @@ class JsonUtility:
             if f_flag:
                 raise StatisticsError(
                     f"{causal_test_case}\n    FAILED - expected {causal_test_case.expected_causal_effect}, "
-                    f"got {result_string}")
+                    f"got {result_string}"
+                )
             failed = True
             logger.warning("   FAILED- expected %s, got %s", causal_test_case.expected_causal_effect, result_string)
         return failed

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -110,10 +110,9 @@ class JsonUtility:
                   f"abstract_test \n" + \
                   f"{abstract_test} \n" + \
                   f"{abstract_test.treatment_variable.name},{abstract_test.treatment_variable.distribution} \n" + \
-                  f"Number of concrete tests for test case: {str(len(concrete_tests))}"
-
-        self.append_to_file(msg, logging.INFO)
-
+                  f"Number of concrete tests for test case: {str(len(concrete_tests))} \n" + \
+                  f"{failures}/{len(concrete_tests)} failed for {test['name']}"
+            self._append_to_file(msg, logging.INFO)
 
     def _execute_tests(self, concrete_tests, estimators, test, f_flag):
         failures = 0
@@ -123,7 +122,6 @@ class JsonUtility:
                 failures += 1
         return failures
 
-
     def _json_parse(self):
         """Parse a JSON input file into inputs, outputs, metas and a test plan"""
         with open(self.input_paths.json_path, encoding="utf-8") as f:
@@ -132,7 +130,6 @@ class JsonUtility:
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)
         self.data = pd.concat(self.data)
-
 
     def _populate_metas(self):
         """
@@ -146,8 +143,7 @@ class JsonUtility:
                 fitter.fit()
                 (dist, params) = list(fitter.get_best(method="sumsquare_error").items())[0]
                 var.distribution = getattr(scipy.stats, dist)(**params)
-                self.append_to_file(var.name + f" {dist}({params})", logging.INFO)
-
+                self._append_to_file(var.name + f" {dist}({params})", logging.INFO)
 
     def _execute_test_case(self, causal_test_case: CausalTestCase, estimator: Estimator, f_flag: bool) -> bool:
         """Executes a singular test case, prints the results and returns the test case result
@@ -181,10 +177,9 @@ class JsonUtility:
             )
         if not test_passes:
             failed = True
-            self.append_to_file(f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}",
-                                logging.WARNING)
+            self._append_to_file(f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}",
+                                 logging.WARNING)
         return failed
-
 
     def _setup_test(self, causal_test_case: CausalTestCase, estimator: Estimator) -> tuple[CausalTestEngine, Estimator]:
         """Create the necessary inputs for a single test case
@@ -214,7 +209,6 @@ class JsonUtility:
 
         return causal_test_engine, estimation_model
 
-
     def add_modelling_assumptions(self, estimation_model: Estimator):  # pylint: disable=unused-argument
         """Optional abstract method where user functionality can be written to determine what assumptions are required
         for specific test cases
@@ -222,19 +216,16 @@ class JsonUtility:
         """
         return
 
-
-    def append_to_file(self, line: str, log_level: int = None):
+    def _append_to_file(self, line: str, log_level: int = None):
         with open(self.output_path, "a") as f:
-            f.write(line+"\n")
+            f.write(line + "\n")
         if log_level:
             logger.log(level=log_level, msg=line)
-
 
     @staticmethod
     def check_file_exists(output_path: Path, overwrite: bool):
         if not overwrite and output_path.is_file():
             raise FileExistsError(f"Chosen file output ({output_path}) already exists")
-
 
     @staticmethod
     def get_args(test_args=None) -> argparse.Namespace:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -42,14 +42,14 @@ class JsonUtility:
     :attr {CausalSpecification} causal_specification:
     """
 
-    def __init__(self, log_path):
+    def __init__(self, output_path):
         self.paths = None
         self.variables = None
         self.data = []
         self.test_plan = None
         self.scenario = None
         self.causal_specification = None
-        self.setup_logger(log_path)
+        self.check_file_exists(Path(output_path))
 
     def set_paths(self, json_path: str, dag_path: str, data_paths: str):
         """
@@ -212,14 +212,9 @@ class JsonUtility:
         return
 
     @staticmethod
-    def setup_logger(log_path: str):
-        """Setups up logging instance for the module and adds a FileHandler stream so all stdout prints are also
-        sent to the logfile
-        :param log_path: Path specifying location and name of the logging file to be used
-        """
-        setup_log = logging.getLogger(__name__)
-        file_handler = logging.FileHandler(Path(log_path))
-        setup_log.addHandler(file_handler)
+    def check_file_exists(output_path: Path):
+        if output_path.is_file():
+            raise FileExistsError("Chosen file output already exists")
 
     @staticmethod
     def get_args(test_args=None) -> argparse.Namespace:
@@ -234,6 +229,11 @@ class JsonUtility:
             "-f",
             help="if included, the script will stop if a test fails",
             action="store_true",
+        )
+        parser.add_argument(
+            "-w",
+            help="Specify to overwrite any existing output files. This can lead to the loss of existing outputs if not careful",
+            action="store_true"
         )
         parser.add_argument(
             "--log_path",

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -219,25 +219,30 @@ class JsonUtility:
         return
 
     def _append_to_file(self, line: str, log_level: int = None):
-        """ Appends given line(s) to the current output file. If log_level is specified it also logs that message to the
+        """Appends given line(s) to the current output file. If log_level is specified it also logs that message to the
         logging level.
         :param line: The line or lines of text to be appended to the file
         :param log_level: An integer representing the logging level as specified by pythons inbuilt logging module. It
         is possible to use the inbuilt logging level variables such as logging.INFO and logging.WARNING
         """
-        with open(self.output_path, "a", encoding='utf-8') as f:
-            f.write(line + "\n", )
+        with open(self.output_path, "a", encoding="utf-8") as f:
+            f.write(
+                line + "\n",
+            )
         if log_level:
             logger.log(level=log_level, msg=line)
 
     @staticmethod
     def check_file_exists(output_path: Path, overwrite: bool):
-        """ Method that checks if the given path to an output file already exists. If overwrite is true the check is
+        """Method that checks if the given path to an output file already exists. If overwrite is true the check is
         passed.
         :param output_path: File path for the output file of the JSON Frontend
         :param overwrite: bool that if true, the current file can be overwritten
         """
-        if not overwrite and output_path.is_file():
+        if overwrite:
+            file = open(output_path, "w", encoding="utf-8")
+            file.close()
+        elif output_path.is_file():
             raise FileExistsError(f"Chosen file output ({output_path}) already exists")
 
     @staticmethod
@@ -257,7 +262,7 @@ class JsonUtility:
         parser.add_argument(
             "-w",
             help="Specify to overwrite any existing output files. This can lead to the loss of existing outputs if not "
-                 "careful",
+            "careful",
             action="store_true",
         )
         parser.add_argument(

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -239,11 +239,11 @@ class JsonUtility:
         :param output_path: File path for the output file of the JSON Frontend
         :param overwrite: bool that if true, the current file can be overwritten
         """
-        if overwrite:
-            file = open(output_path, "w", encoding="utf-8")
-            file.close()
-        elif output_path.is_file():
-            raise FileExistsError(f"Chosen file output ({output_path}) already exists")
+        if output_path.is_file():
+            if overwrite:
+                output_path.unlink()
+            else:
+                raise FileExistsError(f"Chosen file output ({output_path}) already exists")
 
     @staticmethod
     def get_args(test_args=None) -> argparse.Namespace:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -105,12 +105,15 @@ class JsonUtility:
             abstract_test = self._create_abstract_test_case(test, mutates, effects)
 
             concrete_tests, dummy = abstract_test.generate_concrete_tests(5, 0.05)
-            logger.info("Executing test: %s", test["name"])
-            logger.info(abstract_test)
-            logger.info([abstract_test.treatment_variable.name, abstract_test.treatment_variable.distribution])
-            logger.info("Number of concrete tests for test case: %s", str(len(concrete_tests)))
             failures = self._execute_tests(concrete_tests, estimators, test, f_flag)
-            logger.info("%s/%s failed for %s\n", failures, len(concrete_tests), test["name"])
+            msg = f"Executing test: {test['name']} \n" + \
+                  f"abstract_test \n" + \
+                  f"{abstract_test} \n" + \
+                  f"{abstract_test.treatment_variable.name},{abstract_test.treatment_variable.distribution} \n" + \
+                  f"Number of concrete tests for test case: {str(len(concrete_tests))}"
+
+        self.append_to_file(msg, logging.INFO)
+
 
     def _execute_tests(self, concrete_tests, estimators, test, f_flag):
         failures = 0
@@ -120,6 +123,7 @@ class JsonUtility:
                 failures += 1
         return failures
 
+
     def _json_parse(self):
         """Parse a JSON input file into inputs, outputs, metas and a test plan"""
         with open(self.input_paths.json_path, encoding="utf-8") as f:
@@ -128,6 +132,7 @@ class JsonUtility:
             df = pd.read_csv(data_file, header=0)
             self.data.append(df)
         self.data = pd.concat(self.data)
+
 
     def _populate_metas(self):
         """
@@ -141,7 +146,8 @@ class JsonUtility:
                 fitter.fit()
                 (dist, params) = list(fitter.get_best(method="sumsquare_error").items())[0]
                 var.distribution = getattr(scipy.stats, dist)(**params)
-                logger.info(var.name + f" {dist}({params})")
+                self.append_to_file(var.name + f" {dist}({params})", logging.INFO)
+
 
     def _execute_test_case(self, causal_test_case: CausalTestCase, estimator: Estimator, f_flag: bool) -> bool:
         """Executes a singular test case, prints the results and returns the test case result
@@ -175,8 +181,10 @@ class JsonUtility:
             )
         if not test_passes:
             failed = True
-            self.append_to_file(f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}", logging.WARNING)
+            self.append_to_file(f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}",
+                                logging.WARNING)
         return failed
+
 
     def _setup_test(self, causal_test_case: CausalTestCase, estimator: Estimator) -> tuple[CausalTestEngine, Estimator]:
         """Create the necessary inputs for a single test case
@@ -206,22 +214,27 @@ class JsonUtility:
 
         return causal_test_engine, estimation_model
 
+
     def add_modelling_assumptions(self, estimation_model: Estimator):  # pylint: disable=unused-argument
         """Optional abstract method where user functionality can be written to determine what assumptions are required
         for specific test cases
         :param estimation_model: estimator model instance for the current running test.
         """
         return
+
+
     def append_to_file(self, line: str, log_level: int = None):
         with open(self.output_path, "a") as f:
-            f.write('\n'.join(line))
+            f.write(line+"\n")
         if log_level:
             logger.log(level=log_level, msg=line)
+
 
     @staticmethod
     def check_file_exists(output_path: Path, overwrite: bool):
         if not overwrite and output_path.is_file():
             raise FileExistsError(f"Chosen file output ({output_path}) already exists")
+
 
     @staticmethod
     def get_args(test_args=None) -> argparse.Namespace:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -7,6 +7,7 @@ import logging
 
 from dataclasses import dataclass
 from pathlib import Path
+from statistics import StatisticsError
 
 import pandas as pd
 import scipy
@@ -171,16 +172,14 @@ class JsonUtility:
             )
         else:
             result_string = f"{causal_test_result.test_value.value} no confidence intervals"
-        if f_flag:
-            assert test_passes, (
-                f"{causal_test_case}\n    FAILED - expected {causal_test_case.expected_causal_effect}, "
-                f"got {result_string}"
-            )
+
         if not test_passes:
+            if f_flag:
+                raise StatisticsError(
+                    f"{causal_test_case}\n    FAILED - expected {causal_test_case.expected_causal_effect}, "
+                    f"got {result_string}")
             failed = True
-            self._append_to_file(
-                f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}", logging.WARNING
-            )
+            logger.warning("   FAILED- expected %s, got %s", causal_test_case.expected_causal_effect, result_string)
         return failed
 
     def _setup_test(self, causal_test_case: CausalTestCase, estimator: Estimator) -> tuple[CausalTestEngine, Estimator]:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -6,7 +6,6 @@ import json
 import logging
 
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 
 import pandas as pd
@@ -106,12 +105,14 @@ class JsonUtility:
 
             concrete_tests, dummy = abstract_test.generate_concrete_tests(5, 0.05)
             failures = self._execute_tests(concrete_tests, estimators, test, f_flag)
-            msg = f"Executing test: {test['name']} \n" + \
-                  f"abstract_test \n" + \
-                  f"{abstract_test} \n" + \
-                  f"{abstract_test.treatment_variable.name},{abstract_test.treatment_variable.distribution} \n" + \
-                  f"Number of concrete tests for test case: {str(len(concrete_tests))} \n" + \
-                  f"{failures}/{len(concrete_tests)} failed for {test['name']}"
+            msg = (
+                f"Executing test: {test['name']} \n"
+                + "abstract_test \n"
+                + f"{abstract_test} \n"
+                + f"{abstract_test.treatment_variable.name},{abstract_test.treatment_variable.distribution} \n"
+                + f"Number of concrete tests for test case: {str(len(concrete_tests))} \n"
+                + f"{failures}/{len(concrete_tests)} failed for {test['name']}"
+            )
             self._append_to_file(msg, logging.INFO)
 
     def _execute_tests(self, concrete_tests, estimators, test, f_flag):
@@ -177,8 +178,9 @@ class JsonUtility:
             )
         if not test_passes:
             failed = True
-            self._append_to_file(f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}",
-                                 logging.WARNING)
+            self._append_to_file(
+                f"FAILED- expected {causal_test_case.expected_causal_effect}, got {result_string}", logging.WARNING
+            )
         return failed
 
     def _setup_test(self, causal_test_case: CausalTestCase, estimator: Estimator) -> tuple[CausalTestEngine, Estimator]:
@@ -217,13 +219,24 @@ class JsonUtility:
         return
 
     def _append_to_file(self, line: str, log_level: int = None):
-        with open(self.output_path, "a") as f:
-            f.write(line + "\n")
+        """ Appends given line(s) to the current output file. If log_level is specified it also logs that message to the
+        logging level.
+        :param line: The line or lines of text to be appended to the file
+        :param log_level: An integer representing the logging level as specified by pythons inbuilt logging module. It
+        is possible to use the inbuilt logging level variables such as logging.INFO and logging.WARNING
+        """
+        with open(self.output_path, "a", encoding='utf-8') as f:
+            f.write(line + "\n", )
         if log_level:
             logger.log(level=log_level, msg=line)
 
     @staticmethod
     def check_file_exists(output_path: Path, overwrite: bool):
+        """ Method that checks if the given path to an output file already exists. If overwrite is true the check is
+        passed.
+        :param output_path: File path for the output file of the JSON Frontend
+        :param overwrite: bool that if true, the current file can be overwritten
+        """
         if not overwrite and output_path.is_file():
             raise FileExistsError(f"Chosen file output ({output_path}) already exists")
 
@@ -243,8 +256,9 @@ class JsonUtility:
         )
         parser.add_argument(
             "-w",
-            help="Specify to overwrite any existing output files. This can lead to the loss of existing outputs if not careful",
-            action="store_true"
+            help="Specify to overwrite any existing output files. This can lead to the loss of existing outputs if not "
+                 "careful",
+            action="store_true",
         )
         parser.add_argument(
             "--log_path",

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -158,7 +158,7 @@ class LogisticRegressionEstimator(Estimator):
         model = smf.logit(formula=self.formula, data=data).fit(disp=0)
         return model
 
-    def estimate(self, data: pd.DataFrame, adjustment_config:dict = None) -> RegressionResultsWrapper:
+    def estimate(self, data: pd.DataFrame, adjustment_config: dict = None) -> RegressionResultsWrapper:
         """add terms to the dataframe and estimate the outcome from the data
         :param data: A pandas dataframe containing execution data from the system-under-test.
         :param adjustment_config: Dictionary containing the adjustment configuration of the adjustment set

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from statistics import StatisticsError
 import scipy
 import csv
 import json
@@ -72,6 +73,30 @@ class TestJsonClass(unittest.TestCase):
 
     def test_setup_causal_specification(self):
         self.assertIsInstance(self.json_class.causal_specification, CausalSpecification)
+
+    def test_f_flag(self):
+        example_test = {
+            "tests": [
+                {
+                    "name": "test1",
+                    "mutations": {"test_input": "Increase"},
+                    "estimator": "LinearRegressionEstimator",
+                    "estimate_type": "ate",
+                    "effect_modifiers": [],
+                    "expectedEffect": {"test_output": "NoEffect"},
+                    "skip": False,
+                }
+            ]
+        }
+        self.json_class.test_plan = example_test
+        effects = {"NoEffect": NoEffect()}
+        mutates = {
+            "Increase": lambda x: self.json_class.scenario.treatment_variables[x].z3
+                                  > self.json_class.scenario.variables[x].z3
+        }
+        estimators = {"LinearRegressionEstimator": LinearRegressionEstimator}
+        with self.assertRaises(StatisticsError):
+            self.json_class.generate_tests(effects, mutates, estimators, True)
 
     def test_generate_tests_from_json(self):
         example_test = {

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -41,9 +41,9 @@ class TestJsonClass(unittest.TestCase):
         self.json_class.setup(self.scenario)
 
     def test_setting_paths(self):
-        self.assertEqual(self.json_class.paths.json_path, Path(self.json_path))
-        self.assertEqual(self.json_class.paths.dag_path, Path(self.dag_path))
-        self.assertEqual(self.json_class.paths.data_paths, [Path(self.data_path[0])])  # Needs to be list of Paths
+        self.assertEqual(self.json_class.input_paths.json_path, Path(self.json_path))
+        self.assertEqual(self.json_class.input_paths.dag_path, Path(self.dag_path))
+        self.assertEqual(self.json_class.input_paths.data_paths, [Path(self.data_path[0])])  # Needs to be list of Paths
 
     def test_set_inputs(self):
         ctf_input = [Input("test_input", float, self.example_distribution)]

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -29,7 +29,7 @@ class TestJsonClass(unittest.TestCase):
         self.json_path = str(test_data_dir_path / json_file_name)
         self.dag_path = str(test_data_dir_path / dag_file_name)
         self.data_path = [str(test_data_dir_path / data_file_name)]
-        self.json_class = JsonUtility("logs.log")
+        self.json_class = JsonUtility("temp_out.txt", True)
         self.example_distribution = scipy.stats.uniform(1, 10)
         self.input_dict_list = [{"name": "test_input", "datatype": float, "distribution": self.example_distribution}]
         self.output_dict_list = [{"name": "test_output", "datatype": float}]
@@ -95,11 +95,12 @@ class TestJsonClass(unittest.TestCase):
         }
         estimators = {"LinearRegressionEstimator": LinearRegressionEstimator}
 
-        with self.assertLogs() as captured:
-            self.json_class.generate_tests(effects, mutates, estimators, False)
+        self.json_class.generate_tests(effects, mutates, estimators, False)
 
         # Test that the final log message prints that failed tests are printed, which is expected behaviour for this scenario
-        self.assertIn("failed", captured.records[-1].getMessage())
+        with open("temp_out.txt", 'r') as reader:
+            temp_out = reader.readlines()
+        self.assertIn("failed", temp_out[-1])
 
     def tearDown(self) -> None:
         pass


### PR DESCRIPTION
Currently the JSON Frontend uses the python in-built logging module to produce output files. Which is using the module in a way it was not designed and forces everything that is logged in the frontend to also be saved in the final output. 

This PR separates the logger out and adds a file writer. 