### PR TITLE
JSON add estimator formula

### DIFF
--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -225,8 +225,6 @@ class JsonUtility:
 
         return causal_test_engine, estimation_model
 
-
-
     def _append_to_file(self, line: str, log_level: int = None):
         """Appends given line(s) to the current output file. If log_level is specified it also logs that message to the
         logging level.

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -204,13 +204,6 @@ class JsonUtility:
 
         return causal_test_engine, estimation_model
 
-    def add_modelling_assumptions(self, estimation_model: Estimator):  # pylint: disable=unused-argument
-        """Optional abstract method where user functionality can be written to determine what assumptions are required
-        for specific test cases
-        :param estimation_model: estimator model instance for the current running test.
-        """
-        return
-
     @staticmethod
     def setup_logger(log_path: str):
         """Setups up logging instance for the module and adds a FileHandler stream so all stdout prints are also

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -120,6 +120,8 @@ class JsonUtility:
     def _execute_tests(self, concrete_tests, estimators, test, f_flag):
         failures = 0
         test["estimator"] = estimators[test["estimator"]]
+        if "formula" in test:
+            self._append_to_file(f"Estimator formula used for test: {test['formula']}")
         for concrete_test in concrete_tests:
             failed = self._execute_test_case(concrete_test, test, f_flag)
             if failed:
@@ -234,7 +236,7 @@ class JsonUtility:
         """
         with open(self.output_path, "a", encoding="utf-8") as f:
             f.write(
-                line + "\n",
+                line
             )
         if log_level:
             logger.log(level=log_level, msg=line)

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -146,6 +146,7 @@ class JsonUtility:
     def _execute_test_case(self, causal_test_case: CausalTestCase, test: Iterable[Mapping], f_flag: bool) -> bool:
         """Executes a singular test case, prints the results and returns the test case result
         :param causal_test_case: The concrete test case to be executed
+        :param test: Single JSON test definition stored in a mapping (dict)
         :param f_flag: Failure flag that if True the script will stop executing when a test fails.
         :return: A boolean that if True indicates the causal test case passed and if false indicates the test case
          failed.
@@ -178,9 +179,10 @@ class JsonUtility:
             logger.warning("   FAILED- expected %s, got %s", causal_test_case.expected_causal_effect, result_string)
         return failed
 
-    def _setup_test(self, causal_test_case: CausalTestCase, test) -> tuple[CausalTestEngine, Estimator]:
+    def _setup_test(self, causal_test_case: CausalTestCase, test: Mapping) -> tuple[CausalTestEngine, Estimator]:
         """Create the necessary inputs for a single test case
         :param causal_test_case: The concrete test case to be executed
+        :param test: Single JSON test definition stored in a mapping (dict)
         :returns:
                 - causal_test_engine - Test Engine instance for the test being run
                 - estimation_model - Estimator instance for the test being run
@@ -201,7 +203,7 @@ class JsonUtility:
                 outcome=causal_test_case.outcome_variable.name,
                 df=causal_test_engine.scenario_execution_data_df,
                 effect_modifiers=causal_test_case.effect_modifier_configuration,
-                formula=test["formula"]
+                formula=test["formula"],
             )
         else:
             estimation_model = test["estimator"](

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -320,7 +320,7 @@ class LinearRegressionEstimator(Estimator):
             self.formula = formula
         else:
             terms = [treatment] + sorted(list(adjustment_set)) + sorted(list(effect_modifiers))
-            self.formula = f"{outcome} ~ {'+'.join(((terms)))}"
+            self.formula = f"{outcome} ~ {'+'.join(terms)}"
 
         for term in self.effect_modifiers:
             self.adjustment_set.add(term)

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -158,7 +158,7 @@ class LogisticRegressionEstimator(Estimator):
         model = smf.logit(formula=self.formula, data=data).fit(disp=0)
         return model
 
-    def estimate(self, data: pd.DataFrame, adjustment_config:dict = None) -> RegressionResultsWrapper:
+    def estimate(self, data: pd.DataFrame, adjustment_config: dict = None) -> RegressionResultsWrapper:
         """add terms to the dataframe and estimate the outcome from the data
         :param data: A pandas dataframe containing execution data from the system-under-test.
         :param adjustment_config: Dictionary containing the adjustment configuration of the adjustment set

--- a/examples/poisson/example_run_causal_tests.py
+++ b/examples/poisson/example_run_causal_tests.py
@@ -149,15 +149,6 @@ mutates = {
 }
 
 
-class MyJsonUtility(JsonUtility):
-    """Extension of JsonUtility class to add modelling assumptions to the estimator instance"""
-
-    def add_modelling_assumptions(self, estimation_model: Estimator):
-        # Add squared intensity term as a modelling assumption if intensity is the treatment of the test
-        if "intensity" in estimation_model.treatment[0]:
-            estimation_model.intercept = 0
-
-
 def test_run_causal_tests():
     ROOT = os.path.realpath(os.path.dirname(__file__))
 
@@ -166,7 +157,7 @@ def test_run_causal_tests():
     dag_path = f"{ROOT}/dag.dot"
     data_path = f"{ROOT}/data.csv"
 
-    json_utility = MyJsonUtility(log_path)  # Create an instance of the extended JsonUtility class
+    json_utility = JsonUtility(log_path)  # Create an instance of the extended JsonUtility class
     json_utility.set_paths(
         json_path, dag_path, [data_path]
     )  # Set the path to the data.csv, dag.dot and causal_tests.json file
@@ -178,8 +169,8 @@ def test_run_causal_tests():
 
 
 if __name__ == "__main__":
-    args = MyJsonUtility.get_args()
-    json_utility = MyJsonUtility(args.log_path)  # Create an instance of the extended JsonUtility class
+    args = JsonUtility.get_args()
+    json_utility = JsonUtility(args.log_path)  # Create an instance of the extended JsonUtility class
     json_utility.set_paths(
         args.json_path, args.dag_path, args.data_path
     )  # Set the path to the data.csv, dag.dot and causal_tests.json file

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -156,8 +156,7 @@ class TestJsonClass(unittest.TestCase):
         self.assertIn("test_output ~ test_input", ''.join(temp_out))
 
     def tearDown(self) -> None:
-        pass
-        # remove_temp_dir_if_existent()
+        remove_temp_dir_if_existent()
 
 
 def populate_example(*args, **kwargs):


### PR DESCRIPTION
Remove the awkward `add_modelling_assumption` method and allow for estimator formula's to be specified in the JSON file

i.e.
```
"tests": [
      {
        "name": "test1",
        "mutations": {"x": "Increases"},
        "estimator": "exampleEstimator",
        "estimate_type": "ate",
        "effect": "direct",
        "expectedEffect": {"x": "1"},
        "effect_modifiers": {"y": "true"},
        "target_ks_score": null,
        "formula": "x ~ y" 
        "skip": true,
      },
 ]
```

However the formula field is optional and can be omitted entirely. 