### PR TITLE
Logging causal test results

### DIFF
--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -146,7 +146,7 @@ class JsonUtility:
                     )
                 else:
                     abstract_test = self._create_abstract_test_case(test, mutates, effects)
-                    concrete_tests, dummy = abstract_test.generate_concrete_tests(5, 0.05)
+                    concrete_tests, _ = abstract_test.generate_concrete_tests(5, 0.05)
                     failures, _ = self._execute_tests(concrete_tests, test, f_flag)
 
                     msg = (
@@ -176,17 +176,13 @@ class JsonUtility:
                     estimate_type=test["estimate_type"],
                 )
                 failed, _ = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
-                if failed:
-                    result = "failed"
-                else:
-                    result = "passed"
 
                 msg = (
                     f"Executing concrete test: {test['name']} \n"
                     + f"treatment variable: {test['treatment_variable']} \n"
                     + f"outcome_variable = {outcome_variable} \n"
                     + f"control value = {test['control_value']}, treatment value = {test['treatment_value']} \n"
-                    + f"result - {result}"
+                    + f"Result: {'FAILED' if failed else 'Passed'}"
                 )
                 self._append_to_file(msg, logging.INFO)
 

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -135,14 +135,12 @@ class JsonUtility:
                             self.scenario.variables[v] for v in test.get("effect_modifiers", [])
                         },
                     )
-                    result = self._execute_test_case(
-                        causal_test_case=causal_test_case, test=test, f_flag=f_flag
-                    )
-                    result = ("\n  ").join(str(result).split("\n"))
-                    msg = (
-                        f"Executing test: {test['name']} \n"
-                        + f"  {causal_test_case} \n"
-                        + f"  {result[1]}==============\n"
+                    msg = f"Executing test: {test['name']} \n" + f"  {causal_test_case} \n"
+                    result = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
+                    msg += (
+                        "  "
+                        + ("\n  ").join(str(result[1]).split("\n"))
+                        + f"==============\n"
                         + f"  Result: {'FAILED' if result[0] else 'Passed'}"
                     )
                 else:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -143,7 +143,7 @@ class JsonUtility:
                         f"Executing test: {test['name']} \n"
                         + f"  {causal_test_case} \n"
                         + f"  {result[1]}==============\n"
-                        + f"  Result: {'FAILED' if failed[0] else 'Passed'}"
+                        + f"  Result: {'FAILED' if result[0] else 'Passed'}"
                     )
                 else:
                     abstract_test = self._create_abstract_test_case(test, mutates, effects)
@@ -176,7 +176,7 @@ class JsonUtility:
                     treatment_value=test["treatment_value"],
                     estimate_type=test["estimate_type"],
                 )
-                failed, result = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
+                failed, _ = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
                 if failed:
                     result = "failed"
                 else:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -135,20 +135,20 @@ class JsonUtility:
                             self.scenario.variables[v] for v in test.get("effect_modifiers", [])
                         },
                     )
-                    failed, result = self._execute_test_case(
+                    result = self._execute_test_case(
                         causal_test_case=causal_test_case, test=test, f_flag=f_flag
                     )
                     result = ("\n  ").join(str(result).split("\n"))
                     msg = (
                         f"Executing test: {test['name']} \n"
                         + f"  {causal_test_case} \n"
-                        + f"  {result}==============\n"
-                        + f"  Result: {'FAILED' if failed else 'Passed'}"
+                        + f"  {result[1]}==============\n"
+                        + f"  Result: {'FAILED' if failed[0] else 'Passed'}"
                     )
                 else:
                     abstract_test = self._create_abstract_test_case(test, mutates, effects)
                     concrete_tests, dummy = abstract_test.generate_concrete_tests(5, 0.05)
-                    failures, details = self._execute_tests(concrete_tests, test, f_flag)
+                    failures, _ = self._execute_tests(concrete_tests, test, f_flag)
 
                     msg = (
                         f"Executing test: {test['name']} \n"

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -135,12 +135,13 @@ class JsonUtility:
                             self.scenario.variables[v] for v in test.get("effect_modifiers", [])
                         },
                     )
-                    msg = f"Executing test: {test['name']} \n" + f"  {causal_test_case} \n"
                     result = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
-                    msg += (
-                        "  "
+                    msg = (
+                        f"Executing test: {test['name']} \n"
+                        + f"  {causal_test_case} \n"
+                        + "  "
                         + ("\n  ").join(str(result[1]).split("\n"))
-                        + f"==============\n"
+                        + "==============\n"
                         + f"  Result: {'FAILED' if result[0] else 'Passed'}"
                     )
                 else:

--- a/causal_testing/json_front/json_class.py
+++ b/causal_testing/json_front/json_class.py
@@ -135,8 +135,10 @@ class JsonUtility:
                             self.scenario.variables[v] for v in test.get("effect_modifiers", [])
                         },
                     )
-                    failed, result = self._execute_test_case(causal_test_case=causal_test_case, test=test, f_flag=f_flag)
-                    result = ('\n  ').join(str(result).split("\n"))
+                    failed, result = self._execute_test_case(
+                        causal_test_case=causal_test_case, test=test, f_flag=f_flag
+                    )
+                    result = ("\n  ").join(str(result).split("\n"))
                     msg = (
                         f"Executing test: {test['name']} \n"
                         + f"  {causal_test_case} \n"
@@ -217,7 +219,9 @@ class JsonUtility:
         for meta in self.scenario.variables_of_type(Meta):
             meta.populate(self.data)
 
-    def _execute_test_case(self, causal_test_case: CausalTestCase, test: Iterable[Mapping], f_flag: bool) -> (bool, CausalTestResult):
+    def _execute_test_case(
+        self, causal_test_case: CausalTestCase, test: Iterable[Mapping], f_flag: bool
+    ) -> (bool, CausalTestResult):
         """Executes a singular test case, prints the results and returns the test case result
         :param causal_test_case: The concrete test case to be executed
         :param test: Single JSON test definition stored in a mapping (dict)

--- a/causal_testing/testing/causal_test_result.py
+++ b/causal_testing/testing/causal_test_result.py
@@ -3,6 +3,7 @@ TestValue dataclass.
 """
 from typing import Any
 from dataclasses import dataclass
+import pandas as pd
 
 from causal_testing.testing.estimators import Estimator
 from causal_testing.specification.variable import Variable
@@ -87,7 +88,7 @@ class CausalTestResult:
 
     def ci_valid(self) -> bool:
         """Return whether or not the result has valid confidence invervals"""
-        return self.ci_low() and self.ci_high()
+        return self.ci_low() and (not pd.isnull(self.ci_low())) and self.ci_high() and (not pd.isnull(self.ci_high()))
 
     def summary(self):
         """Summarise the causal test result as an intuitive sentence."""

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -123,7 +123,7 @@ class TestJsonClass(unittest.TestCase):
         # Test that the final log message prints that failed tests are printed, which is expected behaviour for this scenario
         with open("temp_out.txt", "r") as reader:
             temp_out = reader.readlines()
-        self.assertIn("failed", temp_out[-1])
+        self.assertIn("FAILED", temp_out[-1])
 
     def test_run_json_tests_from_json(self):
         example_test = {

--- a/tests/json_front_tests/test_json_class.py
+++ b/tests/json_front_tests/test_json_class.py
@@ -234,7 +234,7 @@ class TestJsonClass(unittest.TestCase):
         self.json_class.run_json_tests(effects=effects, estimators=estimators, f_flag=False)
         with open("temp_out.txt", "r") as reader:
             temp_out = reader.readlines()
-        self.assertIn("failed", temp_out[-1])
+        self.assertIn("FAILED", temp_out[-1])
 
     def tearDown(self) -> None:
         remove_temp_dir_if_existent()


### PR DESCRIPTION
I made it so the JSON front end now logs the causal test result directly under some circumstances. I did this for easier interpretation for the CARLA paper.