### PR TITLE
Move to pydot

### DIFF
--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -136,7 +136,6 @@ class CausalDAG(nx.DiGraph):
         if dot_path:
             pydot_graph = pydot.graph_from_dot_file(dot_path)
             self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))
-            self.graph2 = nx.DiGraph(nx.drawing.nx_agraph.read_dot(dot_path))
         else:
             self.graph = nx.DiGraph()
 

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -8,6 +8,7 @@ from random import sample
 from typing import Union
 
 import networkx as nx
+import pydot
 
 from causal_testing.testing.base_test_case import BaseTestCase
 
@@ -133,7 +134,9 @@ class CausalDAG(nx.DiGraph):
     def __init__(self, dot_path: str = None, **attr):
         super().__init__(**attr)
         if dot_path:
-            self.graph = nx.DiGraph(nx.drawing.nx_agraph.read_dot(dot_path))
+            pydot_graph = pydot.graph_from_dot_file(dot_path)
+            self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))
+            self.graph2 = nx.DiGraph(nx.drawing.nx_agraph.read_dot(dot_path))
         else:
             self.graph = nx.DiGraph()
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,16 +6,6 @@ Requirements
 CausalTestingFramework requires python version 3.9 or later
 If installing on Windows, ensure `Microsoft Visual C++ <https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist>`_ is version 14.0 or greater
 
-Pygraphviz
-----------
-
-Pygraphviz can be installed through the conda-forge channel::
-
-    conda install -c conda-forge pygraphviz
-
-
-Alternatively, on Linux systems, this can be done with `sudo apt install graphviz libgraphviz-dev`.
-
 Pip Install
 -----------
 To install the Causal Testing Framework using :code:`pip` for the latest stable version::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "scikit_learn~=1.1",
     "scipy~=1.7",
     "statsmodels~=0.13",
-    "tabulate~=0.8"
+    "tabulate~=0.8",
+    "pydot~=1.4"
 ]
 dynamic = ["version"]
 

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -6,7 +6,6 @@ from tests.test_helpers import create_temp_dir_if_non_existent, remove_temp_dir_
 
 
 class TestCausalDAGIssue90(unittest.TestCase):
-
     """
     Test the CausalDAG class for the resolution of Issue 90.
     """
@@ -62,7 +61,6 @@ class TestIVAssumptions(unittest.TestCase):
 
 
 class TestCausalDAG(unittest.TestCase):
-
     """
     Test the CausalDAG class for creation of Causal Directed Acyclic Graphs (DAGs).
 
@@ -176,19 +174,18 @@ class TestDAGIdentification(unittest.TestCase):
         """Test whether converting a Causal DAG to a proper back-door graph works correctly."""
         causal_dag = CausalDAG(self.dag_dot_path)
         proper_backdoor_graph = causal_dag.get_proper_backdoor_graph(["X1", "X2"], ["Y"])
-        self.assertEqual(
-            list(proper_backdoor_graph.graph.edges),
-            [
-                ("X1", "X2"),
-                ("X2", "V"),
-                ("X2", "D2"),
-                ("D1", "D2"),
-                ("D1", "Y"),
-                ("Y", "D3"),
-                ("Z", "X2"),
-                ("Z", "Y"),
-            ],
-        )
+        edges = set([
+                    ("X1", "X2"),
+                    ("X2", "V"),
+                    ("X2", "D2"),
+                    ("D1", "D2"),
+                    ("D1", "Y"),
+                    ("Y", "D3"),
+                    ("Z", "X2"),
+                    ("Z", "Y"),
+                ])
+        self.assertTrue(
+            set(proper_backdoor_graph.graph.edges).issubset(edges))
 
     def test_constructive_backdoor_criterion_should_hold(self):
         """Test whether the constructive criterion holds when it should."""
@@ -198,7 +195,7 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertTrue(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_constructive_backdoor_criterion_should_not_hold_not_d_separator_in_proper_backdoor_graph(
-        self,
+            self,
     ):
         """Test whether the constructive criterion fails when the adjustment set is not a d-separator."""
         causal_dag = CausalDAG(self.dag_dot_path)
@@ -207,7 +204,7 @@ class TestDAGIdentification(unittest.TestCase):
         self.assertFalse(causal_dag.constructive_backdoor_criterion(proper_backdoor_graph, xs, ys, zs))
 
     def test_constructive_backdoor_criterion_should_not_hold_descendent_of_proper_causal_path(
-        self,
+            self,
     ):
         """Test whether the constructive criterion holds when the adjustment set Z contains a descendent of a variable
         on a proper causal path between X and Y."""
@@ -392,7 +389,6 @@ class TestDependsOnOutputs(unittest.TestCase):
 
 
 class TestUndirectedGraphAlgorithms(unittest.TestCase):
-
     """
     Test the graph algorithms designed for the undirected graph variants of a Causal DAG.
     During the identification process, a Causal DAG is converted into several forms of undirected graph which allow for


### PR DESCRIPTION
Removes the need for Pygraphviz.

Pygraphviz was only used to import graphs. 

Pydot is lighter weight wrapper for graphviz than Pygraphviz and doesn't require conda-forge to install. Also because Pygraphviz requires installing through conda-forge on MacOS and Windows, this removes a step from the installation process for CTF.