### PR TITLE
Expose estimator type params

### DIFF
--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -30,7 +30,7 @@ class CausalTestCase:
         control_value: Any = None,
         treatment_value: Any = None,
         estimate_type: str = "ate",
-        estimate_params: dict = "None",
+        estimate_params: dict = None,
         effect_modifier_configuration: dict[Variable:Any] = None,
     ):
         """
@@ -48,7 +48,8 @@ class CausalTestCase:
         self.treatment_variable = base_test_case.treatment_variable
         self.treatment_value = treatment_value
         self.estimate_type = estimate_type
-        self.estimate_params = estimate_params
+        if estimate_params is None:
+            self.estimate_params = {}
         self.effect = base_test_case.effect
 
         if effect_modifier_configuration:

--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -30,6 +30,7 @@ class CausalTestCase:
         control_value: Any = None,
         treatment_value: Any = None,
         estimate_type: str = "ate",
+        estimate_params: dict = "None",
         effect_modifier_configuration: dict[Variable:Any] = None,
     ):
         """
@@ -47,6 +48,7 @@ class CausalTestCase:
         self.treatment_variable = base_test_case.treatment_variable
         self.treatment_value = treatment_value
         self.estimate_type = estimate_type
+        self.estimate_params = estimate_params
         self.effect = base_test_case.effect
 
         if effect_modifier_configuration:

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -162,7 +162,7 @@ class CausalTestEngine:
             )
         elif causal_test_case.estimate_type == "risk_ratio":
             logger.debug("calculating risk_ratio")
-            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio()
+            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(estimator.params)
             causal_test_result = CausalTestResult(
                 estimator=estimator,
                 test_value=TestValue("risk_ratio", risk_ratio),

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -162,10 +162,8 @@ class CausalTestEngine:
             )
         elif causal_test_case.estimate_type == "risk_ratio":
             logger.debug("calculating risk_ratio")
-            try:
-                risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(causal_test_case.estimate_params)
-            except TypeError:
-                risk_ratio, confidence_intervals = estimator.estimate_risk_ratio()
+            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(**causal_test_case.estimate_params)
+
             causal_test_result = CausalTestResult(
                 estimator=estimator,
                 test_value=TestValue("risk_ratio", risk_ratio),

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -162,7 +162,7 @@ class CausalTestEngine:
             )
         elif causal_test_case.estimate_type == "risk_ratio":
             logger.debug("calculating risk_ratio")
-            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(estimator.params)
+            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(causal_test_case.estimate_params)
             causal_test_result = CausalTestResult(
                 estimator=estimator,
                 test_value=TestValue("risk_ratio", risk_ratio),

--- a/causal_testing/testing/causal_test_engine.py
+++ b/causal_testing/testing/causal_test_engine.py
@@ -162,7 +162,10 @@ class CausalTestEngine:
             )
         elif causal_test_case.estimate_type == "risk_ratio":
             logger.debug("calculating risk_ratio")
-            risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(causal_test_case.estimate_params)
+            try:
+                risk_ratio, confidence_intervals = estimator.estimate_risk_ratio(causal_test_case.estimate_params)
+            except TypeError:
+                risk_ratio, confidence_intervals = estimator.estimate_risk_ratio()
             causal_test_result = CausalTestResult(
                 estimator=estimator,
                 test_value=TestValue("risk_ratio", risk_ratio),

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -215,7 +215,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return (y.iloc[1], np.array(control)), (y.iloc[0], np.array(treatment))
 
-    def estimate_ate(self, estimator_params: dict = {}) -> float:
+    def estimate_ate(self, estimator_params: dict = None) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and take one away from the other. This
@@ -223,8 +223,10 @@ class LogisticRegressionEstimator(Estimator):
 
         :return: The estimated average treatment effect and 95% confidence intervals
         """
-        bootstrap_size = estimator_params.get('bootstrap_size', 100)
-        adjustment_config = estimator_params.get('adjustment_config', None)
+        if estimator_params is None:
+            estimator_params = {}
+        bootstrap_size = estimator_params.get("bootstrap_size", 100)
+        adjustment_config = estimator_params.get("adjustment_config", None)
         (control_outcome, control_bootstraps), (
             treatment_outcome,
             treatment_bootstraps,
@@ -247,7 +249,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return estimate, (ci_low, ci_high)
 
-    def estimate_risk_ratio(self, estimator_params: dict = {}) -> float:
+    def estimate_risk_ratio(self, estimator_params: dict = None) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and divide one by the other. This
@@ -255,8 +257,10 @@ class LogisticRegressionEstimator(Estimator):
 
         :return: The estimated risk ratio and 95% confidence intervals.
         """
-        bootstrap_size = estimator_params.get('bootstrap_size', 100)
-        adjustment_config = estimator_params.get('adjustment_config', None)
+        if estimator_params is None:
+            estimator_params = {}
+        bootstrap_size = estimator_params.get("bootstrap_size", 100)
+        adjustment_config = estimator_params.get("adjustment_config", None)
         (control_outcome, control_bootstraps), (
             treatment_outcome,
             treatment_bootstraps,

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -360,7 +360,7 @@ class LinearRegressionEstimator(Estimator):
             ci_high = ci_high[0]
         return unit_effect, [ci_low, ci_high]
 
-    def estimate_ate(self) -> tuple[float, list[float, float], float]:
+    def estimate_ate(self, estimator_params: dict = None) -> tuple[float, list[float, float], float]:
         """Estimate the average treatment effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value.
 
@@ -411,7 +411,7 @@ class LinearRegressionEstimator(Estimator):
 
         return y.iloc[1], y.iloc[0]
 
-    def estimate_risk_ratio(self) -> tuple[float, list[float, float]]:
+    def estimate_risk_ratio(self, estimator_params: dict = None) -> tuple[float, list[float, float]]:
         """Estimate the risk_ratio effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value.
 

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -179,7 +179,7 @@ class LogisticRegressionEstimator(Estimator):
         # x = x[model.params.index]
         return model.predict(x)
 
-    def estimate_control_treatment(self, bootstrap_size=100, adjustment_config=None) -> tuple[pd.Series, pd.Series]:
+    def estimate_control_treatment(self, bootstrap_size, adjustment_config) -> tuple[pd.Series, pd.Series]:
         """Estimate the outcomes under control and treatment.
 
         :return: The estimated control and treatment values and their confidence
@@ -215,7 +215,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return (y.iloc[1], np.array(control)), (y.iloc[0], np.array(treatment))
 
-    def estimate_ate(self, bootstrap_size=100, adjustment_config=None) -> float:
+    def estimate_ate(self, estimator_params: dict) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and take one away from the other. This
@@ -223,6 +223,8 @@ class LogisticRegressionEstimator(Estimator):
 
         :return: The estimated average treatment effect and 95% confidence intervals
         """
+        bootstrap_size = estimator_params.get('bootstrap_size', 100)
+        adjustment_config = estimator_params.get('adjustment_config', None)
         (control_outcome, control_bootstraps), (
             treatment_outcome,
             treatment_bootstraps,
@@ -245,7 +247,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return estimate, (ci_low, ci_high)
 
-    def estimate_risk_ratio(self, bootstrap_size=100, adjustment_config=None) -> float:
+    def estimate_risk_ratio(self, estimator_params: dict) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and divide one by the other. This
@@ -253,6 +255,8 @@ class LogisticRegressionEstimator(Estimator):
 
         :return: The estimated risk ratio and 95% confidence intervals.
         """
+        bootstrap_size = estimator_params.get('bootstrap_size', 100)
+        adjustment_config = estimator_params.get('adjustment_config', None)
         (control_outcome, control_bootstraps), (
             treatment_outcome,
             treatment_bootstraps,

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -360,7 +360,7 @@ class LinearRegressionEstimator(Estimator):
             ci_high = ci_high[0]
         return unit_effect, [ci_low, ci_high]
 
-    def estimate_ate(self, estimator_params: dict = None) -> tuple[float, list[float, float], float]:
+    def estimate_ate(self) -> tuple[float, list[float, float], float]:
         """Estimate the average treatment effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value.
 
@@ -411,7 +411,7 @@ class LinearRegressionEstimator(Estimator):
 
         return y.iloc[1], y.iloc[0]
 
-    def estimate_risk_ratio(self, estimator_params: dict = None) -> tuple[float, list[float, float]]:
+    def estimate_risk_ratio(self) -> tuple[float, list[float, float]]:
         """Estimate the risk_ratio effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value.
 

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -215,7 +215,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return (y.iloc[1], np.array(control)), (y.iloc[0], np.array(treatment))
 
-    def estimate_ate(self, estimator_params: dict) -> float:
+    def estimate_ate(self, estimator_params: dict = {}) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and take one away from the other. This
@@ -247,7 +247,7 @@ class LogisticRegressionEstimator(Estimator):
 
         return estimate, (ci_low, ci_high)
 
-    def estimate_risk_ratio(self, estimator_params: dict) -> float:
+    def estimate_risk_ratio(self, estimator_params: dict = {}) -> float:
         """Estimate the ate effect of the treatment on the outcome. That is, the change in outcome caused
         by changing the treatment variable from the control value to the treatment value. Here, we actually
         calculate the expected outcomes under control and treatment and divide one by the other. This

--- a/tests/testing_tests/test_estimators.py
+++ b/tests/testing_tests/test_estimators.py
@@ -124,14 +124,14 @@ class TestLogisticRegressionEstimator(unittest.TestCase):
         logistic_regression_estimator = LogisticRegressionEstimator(
             "length_in", 65, 55, {"large_gauge"}, "completed", df
         )
-        ate, _ = logistic_regression_estimator.estimate_ate(adjustment_config={"large_gauge": 0})
+        ate, _ = logistic_regression_estimator.estimate_ate(estimator_params={"adjustment_config": {"large_gauge": 0}})
         self.assertEqual(round(ate, 4), -0.3388)
 
     def test_ate_invalid_adjustment(self):
         df = self.scarf_df.copy()
         logistic_regression_estimator = LogisticRegressionEstimator("length_in", 65, 55, {}, "completed", df)
         with self.assertRaises(ValueError):
-            ate, _ = logistic_regression_estimator.estimate_ate(adjustment_config={"large_gauge": 0})
+            ate, _ = logistic_regression_estimator.estimate_ate(estimator_params={"adjustment_config": {"large_gauge": 0}})
 
     def test_ate_effect_modifiers(self):
         df = self.scarf_df.copy()


### PR DESCRIPTION
This PR relates #203, where parameters such as `adjustment_config` and `bootstrap_size` were not exposed to testers using the CTF. 

The way they are exposed is by a new attribute in `CausalTestCase` called `estimate_params`. Any parameters placed in here will be unpacked in the specific estimator to be used. 

e.g. `estimator_params={"adjustment_config": {"large_gauge": 0}}`

Any feedback on if this is a logical way to expose these parameters or any problems this could cause are very welcome!