### PR TITLE
Windows wheel install

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -22,7 +22,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package and dependencies
         run: |
-          conda install -c conda-forge pygraphviz
           python --version
           pip install -e . --no-cache-dir
           pip install -e .[test]

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install package and dependencies
         run: |
           python --version
-          pip install -e . --no-cache-dir
+          pip install -e .
           pip install -e .[test]
           pip install pytest pytest-cov
         shell: bash -l {0}


### PR DESCRIPTION
This PR removes pygraphviz from ci/cd install which seems to fix the windows VM wheel install problem