### PR TITLE
Add wheel dependency to GH action

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           pip3 install .
           pip3 install .[pypi]
-          pip3 install build
+          pip3 install build wheel
           pip3 install setuptools --upgrade
           pip3 install setuptools_scm
       - name: Build Package


### PR DESCRIPTION
New versions aren't being pushed to PyPI due to wheel dependency is not being found.

Not sure why wheel is suddenly required explicitly. 

