### PR TITLE
Remove getters in test usage and examples

### DIFF
--- a/causal_testing/testing/causal_test_case.py
+++ b/causal_testing/testing/causal_test_case.py
@@ -57,22 +57,6 @@ class CausalTestCase:
         else:
             self.effect_modifier_configuration = {}
 
-    def get_treatment_variable(self):
-        """Return the treatment variable name (as string) for this causal test case"""
-        return self.treatment_variable.name
-
-    def get_outcome_variable(self):
-        """Return the outcome variable name (as string) for this causal test case."""
-        return self.outcome_variable.name
-
-    def get_control_value(self):
-        """Return a the control value of the treatment variable in this causal test case."""
-        return self.control_value
-
-    def get_treatment_value(self):
-        """Return the treatment value of the treatment variable in this causal test case."""
-        return self.treatment_value
-
     def execute_test(self, estimator: type(Estimator), data_collector: DataCollector) -> CausalTestResult:
         """Execute a causal test case and return the causal test result.
 

--- a/examples/poisson-line-process/example_poisson_process.py
+++ b/examples/poisson-line-process/example_poisson_process.py
@@ -90,8 +90,8 @@ def causal_test_intensity_num_shapes(
     # 8. Set up an estimator
     data = pd.read_csv(observational_data_path)
 
-    treatment = causal_test_case.get_treatment_variable()
-    outcome = causal_test_case.get_outcome_variable()
+    treatment = causal_test_case.treatment_variable.name
+    outcome = causal_test_case.outcome_variable.name
 
     estimator = None
     if empirical:

--- a/tests/testing_tests/test_causal_test_case.py
+++ b/tests/testing_tests/test_causal_test_case.py
@@ -37,18 +37,6 @@ class TestCausalTestCase(unittest.TestCase):
             treatment_value=1,
         )
 
-    def test_get_treatment_variable(self):
-        self.assertEqual(self.causal_test_case.get_treatment_variable(), "A")
-
-    def test_get_outcome_variable(self):
-        self.assertEqual(self.causal_test_case.get_outcome_variable(), "C")
-
-    def test_get_treatment_value(self):
-        self.assertEqual(self.causal_test_case.get_treatment_value(), 1)
-
-    def test_get_control_value(self):
-        self.assertEqual(self.causal_test_case.get_control_value(), 0)
-
     def test_str(self):
         self.assertEqual(
             str(self.causal_test_case),


### PR DESCRIPTION
Removed getters in causal_test_case.py, their unit tests in test_causal_test_case.py and changed attributes in example_poisson_process.py - this closes #218 