### PR TITLE
Fixed serialisation bug

### DIFF
--- a/causal_testing/testing/causal_test_result.py
+++ b/causal_testing/testing/causal_test_result.py
@@ -85,9 +85,11 @@ class CausalTestResult:
             "outcome": self.estimator.outcome,
             "adjustment_set": list(self.adjustment_set) if json else self.adjustment_set,
             "effect_measure": self.test_value.type,
-            "effect_estimate": self.test_value.value,
-            "ci_low": self.ci_low(),
-            "ci_high": self.ci_high(),
+            "effect_estimate": self.test_value.value.to_dict()
+            if json and hasattr(self.test_value.value, "to_dict")
+            else self.test_value.value,
+            "ci_low": self.ci_low().to_dict() if json and hasattr(self.ci_low(), "to_dict") else self.ci_low(),
+            "ci_high": self.ci_high().to_dict() if json and hasattr(self.ci_high(), "to_dict") else self.ci_high(),
         }
         if self.adequacy:
             base_dict["adequacy"] = self.adequacy.to_dict()


### PR DESCRIPTION
Fixed a problem with the `to_json` method of causal test result where pandas series weren't json serialisable. Now converting them to a dict.