### PR TITLE
Update versions of packages used by RTD build workflow

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==5.3.0
-myst-parser==0.18.1
-sphinx-autoapi==2.0.1
-sphinx-rtd-theme==1.1.1
+Sphinx==7.2.6
+myst-parser==2.0.0
+sphinx-autoapi==3.0.0
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
It appears the latest docs PR introduces features that are only compatible with sphinx-autoapi >= 3.0.0.

This PR updates the requirements file that ReadTheDocs uses to do it's build of the docs. 