### PR TITLE
Filter out draft PRs from normal ci workflow

### DIFF
--- a/.github/workflows/ci-tests-drafts.yaml
+++ b/.github/workflows/ci-tests-drafts.yaml
@@ -1,18 +1,13 @@
-name: Continuous Integration Tests (pytest)
-
+name: Continuous Integration Tests Draft PR (pytest)
+# This duplicate ci workflow is required so the badge in the README.md is not effected by draft PRs
 on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false # Filter out draft PRs
+    if: github.event.pull_request.draft == true
     name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This duplicate ci workflow is required so the badge in the README.md is not effected by draft PRs