### PR TITLE
Fix: Remove spurious nodes in dot files due to \n

### DIFF
--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -133,7 +133,9 @@ class CausalDAG(nx.DiGraph):
     def __init__(self, dot_path: str = None, **attr):
         super().__init__(**attr)
         if dot_path:
-            pydot_graph = pydot.graph_from_dot_file(dot_path)
+            with open(dot_path, 'r') as file:
+                dot_content = file.read().replace('\n', '')
+            pydot_graph = pydot.graph_from_dot_data(dot_content)
             self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))
         else:
             self.graph = nx.DiGraph()

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -133,7 +133,7 @@ class CausalDAG(nx.DiGraph):
     def __init__(self, dot_path: str = None, **attr):
         super().__init__(**attr)
         if dot_path:
-            with open(dot_path, 'r') as file:
+            with open(dot_path, 'r', encoding='utf-8') as file:
                 dot_content = file.read().replace('\n', '')
             pydot_graph = pydot.graph_from_dot_data(dot_content)
             self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -134,7 +134,7 @@ class CausalDAG(nx.DiGraph):
         super().__init__(**attr)
         if dot_path:
             with open(dot_path, 'r', encoding='utf-8') as file:
-                dot_content = file.read().replace('\n', '')
+                dot_content = file.read().replace('\n', '') # Remove any newlines before creating the pydot_graph.
             pydot_graph = pydot.graph_from_dot_data(dot_content)
             self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))
         else:

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -134,7 +134,10 @@ class CausalDAG(nx.DiGraph):
         super().__init__(**attr)
         if dot_path:
             with open(dot_path, 'r', encoding='utf-8') as file:
-                dot_content = file.read().replace('\n', '') # Remove any newlines before creating the pydot_graph.
+                dot_content = file.read().replace('\n', '')
+            # Previously, we used pydot_graph_from_file() to read in the dot_path directly, however,
+            # this method does not currently have a way of removing spurious nodes.
+            # Workaround: Read in the file using open(), remove new lines, and then create the pydot_graph.
             pydot_graph = pydot.graph_from_dot_data(dot_content)
             self.graph = nx.DiGraph(nx.drawing.nx_pydot.from_pydot(pydot_graph[0]))
         else:


### PR DESCRIPTION
Fixes issue #258 by:

1. Reading in the dot file,
2. Removing any new lines,
3. Passing the contents back into pydot.