### PR TITLE
Temporary workaround for "I(...) not in df" bug

### DIFF
--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -352,7 +352,14 @@ class LinearRegressionEstimator(Estimator):
         model = self._run_linear_regression()
         newline = "\n"
         patsy_md = ModelDesc.from_formula(self.treatment)
-        if any((self.df.dtypes[factor.name()] == 'object' for factor in patsy_md.rhs_termlist[1].factors)):
+        if any(
+            (
+                self.df.dtypes[factor.name()] == "object"
+                for factor in patsy_md.rhs_termlist[1].factors
+                # TODO: Remove the requirement for this as it prevents us from discovering categoricals within I(...) blocks
+                if factor in self.df
+            )
+        ):
             design_info = dmatrix(self.formula.split("~")[1], self.df).design_info
             treatment = design_info.column_names[design_info.term_name_slices[self.treatment]]
         else:


### PR DESCRIPTION
Interaction terms within an `I(...)` block currently throw an error because the dmatrix sees these as atoms, so cannot pull variables from within them. I have implemented a temporary workaround for this which just ignores them, but we will need to get something better in the long term so that we can have categoricals within these blocks