### PR TITLE
Fixing FutureWarningErrors in Pandas v > 2

### DIFF
--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -382,6 +382,10 @@ class LinearRegressionEstimator(Estimator):
 
         # Create an empty individual for the control and treated
         individuals = pd.DataFrame(1, index=["control", "treated"], columns=model.params.index)
+        
+
+        # For Pandas version > 2, we need to explicitly state that the dataframe takes floating-point values
+        individuals = individuals.astype(float)
 
         # It is ABSOLUTELY CRITICAL that these go last, otherwise we can't index
         # the effect with "ate = t_test_results.effect[0]"

--- a/causal_testing/testing/estimators.py
+++ b/causal_testing/testing/estimators.py
@@ -382,7 +382,6 @@ class LinearRegressionEstimator(Estimator):
 
         # Create an empty individual for the control and treated
         individuals = pd.DataFrame(1, index=["control", "treated"], columns=model.params.index)
-        
 
         # For Pandas version > 2, we need to explicitly state that the dataframe takes floating-point values
         individuals = individuals.astype(float)


### PR DESCRIPTION
- Further fix to issue #285 as @jmafoster1 spotted there are additional `FutureWarningErrors` imposed by newer versions of pandas when running the test suite locally. 