### PR TITLE
Amend Metamorphic Relations

### DIFF
--- a/causal_testing/specification/metamorphic_relation.py
+++ b/causal_testing/specification/metamorphic_relation.py
@@ -214,15 +214,17 @@ class MetamorphicTest:
         )
 
 
-def generate_metamorphic_relations(dag: CausalDAG, skip_ancestors: bool) -> list[MetamorphicRelation]:
+def generate_metamorphic_relations(dag: CausalDAG, skip_ancestors: bool = False) -> list[MetamorphicRelation]:
     """Construct a list of metamorphic relations based on the DAG or cyclic graph.
 
-    If is_causal_dag is True, this list contains a ShouldCause relation for every edge, and a ShouldNotCause
-    relation for every (minimal) conditional independence relation implied by the structure of the DAG.
-    If is_causal_dag is False, it skips checks assuming the graph is acyclic and works on general graphs with loops/cycles.
+    If skip_ancestors is False, this list contains a ShouldCause relation for every edge, and a 
+    ShouldNotCause relation for every (minimal) conditional independence relation implied by 
+    the structure of the DAG. If skip_ancestors is True, it skips checks assuming the graph 
+    is acyclic and works on general graphs with loops/cycles.
 
     :param CausalDAG dag: Graph from which the metamorphic relations will be generated.
-    :param bool is_causal_dag: Specifies whether the input graph is a causal DAG or a cyclic graph.
+    :param bool skip_ancestors: Boolean parameter to determine if the ancestor checks 
+     should be skipped. Default is False.
     :return: A list containing ShouldCause and ShouldNotCause metamorphic relations.
     """
     metamorphic_relations = []

--- a/tests/specification_tests/test_metamorphic_relations.py
+++ b/tests/specification_tests/test_metamorphic_relations.py
@@ -205,7 +205,7 @@ class TestMetamorphicRelation(unittest.TestCase):
     def test_all_metamorphic_relations_implied_by_dag(self):
         dag = CausalDAG(self.dag_dot_path)
         dag.add_edge("Z", "Y")  # Add a direct path from Z to Y so M becomes a mediator
-        metamorphic_relations = generate_metamorphic_relations(dag)
+        metamorphic_relations = generate_metamorphic_relations(dag, skip_ancestors=False)
         should_cause_relations = [mr for mr in metamorphic_relations if isinstance(mr, ShouldCause)]
         should_not_cause_relations = [mr for mr in metamorphic_relations if isinstance(mr, ShouldNotCause)]
 


### PR DESCRIPTION
- Added a simple logic to the function `generate_metamorphic_relations` in `specification/metamorphic_relation.py` to deal with situations with dags that contain cycles/loops.
- The added feature is a boolean parameter called `skip_ancestors`. The default is `False` which retains the original logic of the algorithm. If `True`, no adjustment sets are calculated and empty sets are passed into the `ShouldCase`/`ShouldNotCause` methods. 
- Logging is also used in the script's entry-point to warn the user to proceed with caution if this parameter is true.

TODO:

- [ ] Write unit tests to validate the functionality of the algorithm when `skip_ancestors=True` 