### PR TITLE
Python Version Updates to CI/CD Workflows

### DIFF
--- a/.github/workflows/publish-to-dafni.yaml
+++ b/.github/workflows/publish-to-dafni.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Build the container
         run: |

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Installing package
         run: |
           pip3 install .


### PR DESCRIPTION
- Fixes to GH Actions CI/CD causing error due to old Python versions. Closes issue #295 