### PR TITLE
Fix: Python Version Updates to CI/CD Workflows

### DIFF
--- a/.github/workflows/publish-to-dafni.yaml
+++ b/.github/workflows/publish-to-dafni.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Build the container
         run: |

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Installing package
         run: |
           pip3 install .

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ system-under-test that is expected to cause a change to some output(s).
 ## Installation
 
 ### Requirements
-- Python 3.9, 3.10, 3.11 and 3.12
+- Python 3.10, 3.11 and 3.12
 
 - Microsoft Visual C++ 14.0+ (Windows only).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "causal_testing_framework"
 authors = [{ name = "The CITCOM team" }]
 description = "A framework for causal testing using causal directed acyclic graphs."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 keywords = ["causal inference", "verification"]
 dependencies = [
@@ -63,7 +63,7 @@ find = { }
 [tool.black]
 # https://github.com/psf/black
 line-length = 120
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.autopep8]
 max_line_length = 120


### PR DESCRIPTION
- Fix to previous PR. YAML parses unquoted value as a number, e.g. `python-verison: 3.10` was parsed as `python-version: 3.1`. (see  the raft of mentions by others [here](https://github.com/actions/setup-python/issues/160#issuecomment-724485470))