### PR TITLE
Fixed GP fitness again

### DIFF
--- a/causal_testing/estimation/genetic_programming_regression_fitter.py
+++ b/causal_testing/estimation/genetic_programming_regression_fitter.py
@@ -294,7 +294,7 @@ class GP:
             sqerrors = (self.df[self.outcome] - y_estimates) ** 2
             nrmse = np.sqrt(sqerrors.sum() / len(self.df)) / (self.df[self.outcome].max() - self.df[self.outcome].min())
 
-            if pd.isnull(nrmse) or nrmse.real != nrmse:
+            if pd.isnull(nrmse) or nrmse.real != nrmse or y_estimates.dtype != self.df.dtypes[self.outcome]:
                 return (float("inf"),)
 
             return (nrmse,)


### PR DESCRIPTION
The fitness function would still, very rarely, give a fitness that was a complex number. I think this was because some of the predicted values from candidate functions would evaluate `sqrt(-1)`, which would then give complex distances, and thus a complex fitness. I now return `float("inf")` if the dtype of the predicted values is not the same as the dtype of the expected values, which should hopefully fix the problem in a robust way.