### PR TITLE
Update codecov-actions in CI workflows

### DIFF
--- a/.github/workflows/ci-tests-drafts.yaml
+++ b/.github/workflows/ci-tests-drafts.yaml
@@ -30,8 +30,7 @@ jobs:
       run: |
         pytest --cov=causal_testing --cov-report=xml
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        version: "v0.1.15"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -36,8 +36,7 @@ jobs:
       run: |
         pytest --cov=causal_testing --cov-report=xml
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        version: "v0.1.15"


### PR DESCRIPTION
 - Updated `codecov-actions` in our CI workflow files (`ci-tests.yml` and `ci-tests-drafts.yml`) to allow code coverage uploads from forked pull requests. 
 - See my [comment](https://github.com/CITCOM-project/CausalTestingFramework/pull/310#issuecomment-2685351328) in PR #310 for further details.