### PR TITLE
Validation to check that outcome and treatment aren't the same

### DIFF
--- a/causal_testing/testing/base_test_case.py
+++ b/causal_testing/testing/base_test_case.py
@@ -14,6 +14,9 @@ class BaseTestCase:
     :param effect: A string representing the effect, current support effects are 'direct' and 'total'
     """
 
-    treatment_variable: Variable
-    outcome_variable: Variable
-    effect: str = Effect.TOTAL.value
+    def __init__(self, treatment_variable: Variable, outcome_variable: Variable, effect: str = Effect.TOTAL.value):
+        if treatment_variable == outcome_variable:
+            raise ValueError(f"Treatment variable {treatment_variable} cannot also be the outcome.")
+        self.treatment_variable = treatment_variable
+        self.outcome_variable = outcome_variable
+        self.effect = effect


### PR DESCRIPTION
Closes #114. Added validation in `BaseTestCase` to check that treatment and outcome are not the same.