### PR TITLE
Precompile Wheels for Different OS and Python Versions Before Publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,4 +1,4 @@
-name: Publish python PyPI
+name: Publish to PyPI
 
 on:
   push:
@@ -6,27 +6,88 @@ on:
       - v*
 
 jobs:
-  build-release:
-    name: Build and publish PyPI
+  # First job is to build the wheels on different OS
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip and install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp312-*"
+          CIBW_SKIP: "pp* *musllinux*"
+          CIBW_TEST_SKIP: "*"
+          CIBW_ARCHS_MACOS: "universal2"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+
+      - name: Upload built wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  # Then just build the source distribution as normal
+  build_sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.12"
 
-      - name: Install build tools
+      - name: Upgrade pip and install build
         run: |
-          pip install --upgrade pip setuptools wheel build setuptools_scm
+          python -m pip install --upgrade pip
+          pip install build
 
-      - name: Build Package
+      - name: Build sdist
+        run: python -m build --sdist --outdir dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  # Finally publish all files to PyPI
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+
+      - name: Merge all distributions
         run: |
-          python -m build --no-isolation
+          mkdir -p final_dist
+          find dist -name '*.whl' -exec cp {} final_dist/ \;
+          find dist -name '*.tar.gz' -exec cp {} final_dist/ \;
 
-      - name: Publish package to PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: final_dist


### PR DESCRIPTION
- Fixes to our CD pipeline. The workflow now builds and publishes Python wheels for multiple operating systems and Python versions.
- It uses `cibuildwheel` to generate wheels for Ubuntu, macOS (including Apple Silicon arm64), and Windows, supporting Python 3.10, 3.11, and 3.12. 
- Source distribution is included for completeness. 
- All artifacts are collected and published to PyPI, ensuring all modern CPU architectures are covered too.
- Ultimately, users don't need to have compilers (such as Microsoft C++) installed to compile the CTF. Closes #347 and #343   