### PR TITLE
Strip Unused Dependencies

### DIFF
--- a/causal_testing/specification/variable.py
+++ b/causal_testing/specification/variable.py
@@ -5,7 +5,6 @@ from abc import ABC
 from collections.abc import Callable
 from typing import TypeVar
 
-import lhsmdu
 from pandas import DataFrame
 from scipy.stats._distn_infrastructure import rv_generic
 
@@ -37,19 +36,6 @@ class Variable(ABC):
 
     def __repr__(self):
         return f"{self.typestring()}: {self.name}::{self.datatype.__name__}"
-
-    def sample(self, n_samples: int) -> [T]:
-        """Generate a Latin Hypercube Sample of size n_samples according to the
-        Variable's distribution.
-
-        :param int n_samples: The number of samples to generate.
-        :return: A list of samples
-        :rtype: List[T]
-
-        """
-        assert self.distribution is not None, "Sampling requires a distribution to be specified."
-        lhs = lhsmdu.sample(1, n_samples).tolist()[0]
-        return lhsmdu.inverseTransformSample(self.distribution, lhs).tolist()
 
     def typestring(self) -> str:
         """Return the type of the Variable, e.g. INPUT, or OUTPUT. Note that

--- a/causal_testing/testing/metamorphic_relation.py
+++ b/causal_testing/testing/metamorphic_relation.py
@@ -39,14 +39,14 @@ class ShouldCause(MetamorphicRelation):
 
     def to_json_stub(
         self,
-        skip: bool = True,
+        skip: bool = False,
         estimate_type: str = "coefficient",
         effect_type: str = "direct",
         estimator: str = "LinearRegressionEstimator",
     ) -> dict:
         """
         Convert to a JSON frontend stub string for user customisation.
-        :param skip: Whether to skip the test
+        :param skip: Whether to skip the test (default False).
         :param effect_type: The type of causal effect to consider (total or direct)
         :param estimate_type: The estimate type to use when evaluating tests
         :param estimator: The name of the estimator class to use when evaluating the test
@@ -77,14 +77,14 @@ class ShouldNotCause(MetamorphicRelation):
 
     def to_json_stub(
         self,
-        skip: bool = True,
+        skip: bool = False,
         estimate_type: str = "coefficient",
         effect_type: str = "direct",
         estimator: str = "LinearRegressionEstimator",
     ) -> dict:
         """
         Convert to a JSON frontend stub string for user customisation.
-        :param skip: Whether to skip the test
+        :param skip: Whether to skip the test (default False).
         :param effect_type: The type of causal effect to consider (total or direct)
         :param estimate_type: The estimate type to use when evaluating tests
         :param estimator: The name of the estimator class to use when evaluating the test
@@ -243,6 +243,10 @@ def generate_causal_tests(
         for relation in relations
         if len(list(causal_dag.graph.predecessors(relation.base_test_case.outcome_variable))) > 0
     ]
+
+    logger.warning("The skip parameter is hard-coded to False during test generation for better integration with the "
+                   "causal testing component (python -m causal_testing test ...)"
+                   "Please carefully review the generated tests and decide which to skip.")
 
     logger.info(f"Generated {len(tests)} tests. Saving to {output_path}.")
     with open(output_path, "w", encoding="utf-8") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 keywords = ["causal inference", "verification"]
 dependencies = [
-    "fitter~=1.7",
     "lifelines~=0.29.0",
-    "lhsmdu~=1.1",
     "networkx>=3.4,<3.5",
     "numpy~=1.26",
     "pandas>=2.1",

--- a/tests/specification_tests/test_variable.py
+++ b/tests/specification_tests/test_variable.py
@@ -13,10 +13,6 @@ class TestVariable(unittest.TestCase):
     def setUp(self) -> None:
         pass
 
-    def test_sample_flakey(self):
-        ip = Input("ip", float, norm)
-        self.assertGreater(kstest(ip.sample(10), norm.cdf).pvalue, 0.95)
-
     def test_typestring(self):
         class Var(Variable):
             pass


### PR DESCRIPTION
- PR to remove unused dependencies, including `lhsmdu` and `fitter`. 
   - Removed the import and usage of `lhsmdu` in `causal_testing/specification/variable.py`, including the `sample` method that     used Latin Hypercube Sampling. Both dependencies are also removed from `pyproject.toml`. 
    - Removed the flaky test related to the sampling method in `tests/specification_tests/test_variable.py`. 

- It also updates the default behaviour for test generation to not skip tests. 
   - Changed the default value of the `skip` parameter in the `to_json_stub` methods of `ShouldCause` and `ShouldNotCause` to `False`, and updated the docstrings accordingly. 
    - Added a warning message in `generate_causal_tests` to inform users that the `skip` parameter is now hard-coded to `False` for better integration, and to encourage careful review of generated tests.