### PR TITLE
Fixed numpy linalg error

### DIFF
--- a/causal_testing/discovery/abstract_discovery.py
+++ b/causal_testing/discovery/abstract_discovery.py
@@ -10,6 +10,7 @@ from enum import Enum
 from itertools import permutations
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 import rustworkx as rx
 
@@ -207,19 +208,9 @@ class Discovery(ABC):
 
         results = []
 
-        # We use "silent=False" here to allow for inestimable edges, but it'd be good to have a more stringent
-        # error catching strategy to catch "genuine" problems (e.g. to do with the structure of the data)
-        for test_case, result in zip(ctf.test_cases, ctf.run_tests(silent=False)):
-            if result.effect_estimate is None:
-                results.append(
-                    {
-                        "result": TestResult.INESTIMABLE,
-                        "expected_effect": test_case.expected_causal_effect.__class__.__name__,
-                        "treatment": test_case.base_test_case.treatment_variable.name,
-                        "outcome": test_case.base_test_case.outcome_variable.name,
-                    }
-                )
-            else:
+        for test_case, result in zip(ctf.test_cases, ctf.test_cases):
+            try:
+                result = test_case.execute_test()
                 results.append(
                     {
                         "result": (
@@ -229,6 +220,15 @@ class Discovery(ABC):
                         "treatment": test_case.base_test_case.treatment_variable.name,
                         "outcome": test_case.base_test_case.outcome_variable.name,
                         "effect": effect_direction(result),
+                    }
+                )
+            except np.linalg.LinAlgError:
+                results.append(
+                    {
+                        "result": TestResult.INESTIMABLE,
+                        "expected_effect": test_case.expected_causal_effect.__class__.__name__,
+                        "treatment": test_case.base_test_case.treatment_variable.name,
+                        "outcome": test_case.base_test_case.outcome_variable.name,
                     }
                 )
 

--- a/tests/discovery_tests/test_abstract_discovery.py
+++ b/tests/discovery_tests/test_abstract_discovery.py
@@ -178,6 +178,7 @@ class TestAbstractHillClimber(unittest.TestCase):
 
     def test_evaluate_tests_inestimable(self):
         scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")
+        scarf_df["completed"] = scarf_df["completed"].astype(bool)
         scarf_df = scarf_df.loc[(scarf_df["completed"]) & (scarf_df["color"] != "grey")]
 
         dag = CausalDAG()
@@ -186,6 +187,7 @@ class TestAbstractHillClimber(unittest.TestCase):
 
         abstract_discovery = AbstractDiscovery(scarf_df)
         test_results = abstract_discovery.evaluate_tests(dag)
+        print(test_results)
         expected_results = pd.DataFrame(
             [
                 {
@@ -221,7 +223,7 @@ class TestAbstractHillClimber(unittest.TestCase):
                     "expected_effect": "SomeEffect",
                     "treatment": "length_in",
                     "outcome": "completed",
-                    "effect": "negative",
+                    "effect": "positive",
                 },
                 {
                     "result": TestResult.PASS,
@@ -245,7 +247,7 @@ class TestAbstractHillClimber(unittest.TestCase):
                     "effect": "negative",
                 },
                 {
-                    "result": TestResult.PASS,
+                    "result": TestResult.INESTIMABLE,
                     "expected_effect": "NoEffect",
                     "treatment": "color",
                     "outcome": "completed",
@@ -260,6 +262,7 @@ class TestAbstractHillClimber(unittest.TestCase):
                 },
             ]
         )
+        print(expected_results)
         pd.testing.assert_frame_equal(test_results, expected_results)
 
     def test_evaluate_tests(self):

--- a/tests/discovery_tests/test_abstract_discovery.py
+++ b/tests/discovery_tests/test_abstract_discovery.py
@@ -176,6 +176,92 @@ class TestAbstractHillClimber(unittest.TestCase):
         with self.assertRaises(ValueError):
             abstract_discovery.write_dot(dag, "dag.dot")
 
+    def test_evaluate_tests_inestimable(self):
+        scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")
+        scarf_df = scarf_df.loc[(scarf_df["completed"]) & (scarf_df["color"] != "grey")]
+
+        dag = CausalDAG()
+        dag.add_nodes_from(scarf_df.columns)
+        dag.add_edges_from([("length_in", "completed"), ("large_gauge", "completed")])
+
+        abstract_discovery = AbstractDiscovery(scarf_df)
+        test_results = abstract_discovery.evaluate_tests(dag)
+        expected_results = pd.DataFrame(
+            [
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "length_in",
+                    "outcome": "large_gauge",
+                    "effect": "negative",
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "large_gauge",
+                    "outcome": "length_in",
+                    "effect": "negative",
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "length_in",
+                    "outcome": "color",
+                    "effect": None,
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "color",
+                    "outcome": "length_in",
+                    "effect": None,
+                },
+                {
+                    "result": TestResult.FAIL,
+                    "expected_effect": "SomeEffect",
+                    "treatment": "length_in",
+                    "outcome": "completed",
+                    "effect": "negative",
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "large_gauge",
+                    "outcome": "color",
+                    "effect": None,
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "color",
+                    "outcome": "large_gauge",
+                    "effect": None,
+                },
+                {
+                    "result": TestResult.FAIL,
+                    "expected_effect": "SomeEffect",
+                    "treatment": "large_gauge",
+                    "outcome": "completed",
+                    "effect": "negative",
+                },
+                {
+                    "result": TestResult.PASS,
+                    "expected_effect": "NoEffect",
+                    "treatment": "color",
+                    "outcome": "completed",
+                    "effect": None,
+                },
+                {
+                    "result": TestResult.INESTIMABLE,
+                    "expected_effect": "NoEffect",
+                    "treatment": "completed",
+                    "outcome": "color",
+                    "effect": None,
+                },
+            ]
+        )
+        pd.testing.assert_frame_equal(test_results, expected_results)
+
     def test_evaluate_tests(self):
         scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")
 

--- a/tests/discovery_tests/test_abstract_discovery.py
+++ b/tests/discovery_tests/test_abstract_discovery.py
@@ -176,6 +176,18 @@ class TestAbstractHillClimber(unittest.TestCase):
         with self.assertRaises(ValueError):
             abstract_discovery.write_dot(dag, "dag.dot")
 
+    def test_evaluate_tests_invalid_datatype(self):
+        scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")
+        scarf_df["completed"] = pd.to_datetime(["2026-01-01" for _ in range(len(scarf_df))], format="%Y-%m-%d")
+
+        dag = CausalDAG()
+        dag.add_nodes_from(scarf_df.columns)
+        dag.add_edges_from([("length_in", "completed"), ("large_gauge", "completed")])
+
+        abstract_discovery = AbstractDiscovery(scarf_df)
+        with self.assertRaises(ValueError):
+            abstract_discovery.evaluate_tests(dag)
+
     def test_evaluate_tests_inestimable(self):
         scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")
         scarf_df["completed"] = scarf_df["completed"].astype(bool)
@@ -187,7 +199,6 @@ class TestAbstractHillClimber(unittest.TestCase):
 
         abstract_discovery = AbstractDiscovery(scarf_df)
         test_results = abstract_discovery.evaluate_tests(dag)
-        print(test_results)
         expected_results = pd.DataFrame(
             [
                 {
@@ -262,7 +273,6 @@ class TestAbstractHillClimber(unittest.TestCase):
                 },
             ]
         )
-        print(expected_results)
         pd.testing.assert_frame_equal(test_results, expected_results)
 
     def test_evaluate_tests(self):


### PR DESCRIPTION
The `silent=False` parameter loudly fails if we get errors executing tests (which is good, because there might be genuine errors with the data formatting, etc.), but we do need to catch some errors.