### PR TITLE
Causal discovery context node 

### DIFF
--- a/causal_testing/__main__.py
+++ b/causal_testing/__main__.py
@@ -58,11 +58,23 @@ def main() -> None:
                 kwargs[split[0]] = split[1]
 
             logging.info("Discovering causal structure")
-            # Need to reset index to allow for multiple files having the same index (i.e. starting at zero).
-            # Otherwise you end up with duplicate indices, which causes problems further down the line
-            df = pd.concat([pd.read_csv(path) for path in args.data_paths]).reset_index()
-            if args.variables:
-                df = df[args.variables]
+            
+            if args.context:
+                dfs = []
+                for i, path in enumerate(args.data_paths):
+                    temp_df = pd.read_csv(path)
+                    temp_df['file_index'] = i
+                    dfs.append(temp_df)
+                df = pd.concat(dfs, ignore_index=True)
+                
+                if args.variables:
+                    df = df[list(set(args.variables + ['file_index']))]
+            else:
+                # Need to reset index to allow for multiple files having the same index (i.e. starting at zero).
+                # Otherwise you end up with duplicate indices, which causes problems further down the line
+                df = pd.concat([pd.read_csv(path) for path in args.data_paths]).reset_index()
+                if args.variables:
+                    df = df[args.variables]
 
             discover_class = discover_map[args.technique].load()
             discover = discover_class(

--- a/causal_testing/__main__.py
+++ b/causal_testing/__main__.py
@@ -58,6 +58,7 @@ def main() -> None:
                 kwargs[split[0]] = split[1]
 
             logging.info("Discovering causal structure")
+            exclude_edges = list(nx.nx_pydot.read_dot(args.exclude_edges).edges()) if args.exclude_edges is not None else []
             
             if args.context:
                 dfs = []
@@ -65,23 +66,23 @@ def main() -> None:
                     temp_df = pd.read_csv(path)
                     temp_df['file_index'] = i
                     dfs.append(temp_df)
+
                 df = pd.concat(dfs, ignore_index=True)
                 
                 if args.variables:
                     df = df[list(set(args.variables + ['file_index']))]
+
+                exclude_edges.append('".*" -> file_index')
             else:
-                # Need to reset index to allow for multiple files having the same index (i.e. starting at zero).
-                # Otherwise you end up with duplicate indices, which causes problems further down the line
-                df = pd.concat([pd.read_csv(path) for path in args.data_paths]).reset_index()
+                df = pd.concat((pd.read_csv(path) for path in args.data_paths), ignore_index=True)
+                
                 if args.variables:
                     df = df[args.variables]
 
             discover_class = discover_map[args.technique].load()
             discover = discover_class(
                 df=df,
-                exclude_edges=(
-                    list(nx.nx_pydot.read_dot(args.exclude_edges).edges()) if args.exclude_edges is not None else []
-                ),
+                exclude_edges=exclude_edges,
                 include_edges=(
                     list(nx.nx_pydot.read_dot(args.include_edges).edges()) if args.include_edges is not None else []
                 ),

--- a/causal_testing/__main__.py
+++ b/causal_testing/__main__.py
@@ -72,7 +72,7 @@ def main() -> None:
                 if args.variables:
                     df = df[list(set(args.variables + ['file_index']))]
 
-                exclude_edges.append('".*" -> file_index')
+                exclude_edges.append((".*", "file_index"))
             else:
                 df = pd.concat((pd.read_csv(path) for path in args.data_paths), ignore_index=True)
                 

--- a/causal_testing/discovery/abstract_discovery.py
+++ b/causal_testing/discovery/abstract_discovery.py
@@ -166,6 +166,9 @@ class Discovery(ABC):
                     else:
                         raise ValueError(f"Invalid test outcome {test['result']}")
 
+        individual.remove_node("index")
+        if "file_index" in individual.nodes:
+            individual.remove_node("file_index")
         nx.drawing.nx_pydot.write_dot(individual, output_file)
 
     def _json_stub_params(self, outcome: str) -> str:

--- a/causal_testing/discovery/abstract_discovery.py
+++ b/causal_testing/discovery/abstract_discovery.py
@@ -166,7 +166,6 @@ class Discovery(ABC):
                     else:
                         raise ValueError(f"Invalid test outcome {test['result']}")
 
-        individual.remove_node("index")
         if "file_index" in individual.nodes:
             individual.remove_node("file_index")
         nx.drawing.nx_pydot.write_dot(individual, output_file)

--- a/causal_testing/main.py
+++ b/causal_testing/main.py
@@ -591,6 +591,14 @@ def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser_discover = subparsers.add_parser(Command.DISCOVER.value, help="Discover causal structures from data")
     parser_discover.add_argument("-d", "--data-paths", help="Paths to data files (.csv)", nargs="+", required=True)
     parser_discover.add_argument(
+        "-c",
+        "--context",
+        help="Combine data from multiple files into a single DataFrame using a context node rather than concatenation",
+        action="store_true",
+        default=False,
+        required=False,
+    )
+    parser_discover.add_argument(
         "-a",
         "--alpha",
         help=(


### PR DESCRIPTION
Data from multiple files needs to be treated different if the data is simply split across files or has additional context to each file 