### PR TITLE
Little fixes to facilitate the sharr evaluation

### DIFF
--- a/causal_testing/__main__.py
+++ b/causal_testing/__main__.py
@@ -215,7 +215,7 @@ def main() -> None:
             logging.info("Discovering causal structure")
             # Need to reset index to allow for multiple files having the same index (i.e. starting at zero).
             # Otherwise you end up with duplicate indices, which causes problems further down the line
-            df = pd.concat([read_dataframe(path) for path in args.data_paths]).reset_index()
+            df = pd.concat([read_dataframe(path) for path in args.data_paths]).reset_index(drop=True)
             if args.variables:
                 df = df[args.variables]
             # Drop unnamed columns
@@ -237,7 +237,8 @@ def main() -> None:
                 **kwargs,
             )
             evolved_dag = discover.discover()
-            discover.write_dot(evolved_dag, args.output)
+            if args.output is not None:
+                nx.drawing.nx_pydot.write_dot(evolved_dag, args.output)
             logging.info("Causal structure discovery completed successfully.")
         case Command.TEST:
             # Create and setup framework

--- a/causal_testing/causal_testing_framework.py
+++ b/causal_testing/causal_testing_framework.py
@@ -236,7 +236,7 @@ class CausalTestingFramework:
         }
 
         sample_results = []
-        for sample_index in range(bootstrap_size):
+        for sample_index in tqdm(range(bootstrap_size)):
             test_outcomes = {test_outcome: 0 for test_outcome in TestOutcome}
             for test_case in self.test_cases:
                 if test_case.skip:

--- a/causal_testing/discovery/hill_climber_discovery.py
+++ b/causal_testing/discovery/hill_climber_discovery.py
@@ -7,6 +7,7 @@ import time
 
 import numpy as np
 import pandas as pd
+from tqdm import tqdm
 
 from causal_testing.discovery.abstract_discovery import Discovery
 from causal_testing.specification.causal_dag import CausalDAG
@@ -116,11 +117,11 @@ class HillClimberDiscovery(Discovery):
         self.remove_cycles(individual)
         fitness_values, problem_edges = self.evaluate_fitness(individual)
 
-        iterations = self.max_iterations
         iterations_without_improvement = 0
 
-        while problem_edges and iterations:
-            iterations -= 1
+        for _ in tqdm(range(self.max_iterations)):
+            if not problem_edges:
+                break
 
             new_individual = individual.copy()
             for origin, dest in random.sample(

--- a/causal_testing/discovery/hill_climber_discovery.py
+++ b/causal_testing/discovery/hill_climber_discovery.py
@@ -3,7 +3,6 @@ This module implements a hill climbing algorithm to optimise causal DAGs based o
 """
 
 import random
-import time
 
 import numpy as np
 import pandas as pd
@@ -95,11 +94,12 @@ class HillClimberDiscovery(Discovery):
             or ~(group["result"] == TestOutcome.PASS).any()
         )
         problem_edges = problem_tests[["treatment", "outcome"]].apply(tuple, axis=1).tolist()
+        num_tests = sum(counts.values())
 
         fitness_values = (
-            counts.get(TestOutcome.PASS, 0),
-            -counts.get(TestOutcome.FAIL, 0),
-            -counts.get(TestOutcome.INESTIMABLE, 0),
+            counts.get(TestOutcome.PASS, 0) / num_tests,
+            -counts.get(TestOutcome.FAIL, 0) / num_tests,
+            -counts.get(TestOutcome.INESTIMABLE, 0) / num_tests,
         )
         return fitness_values, problem_edges
 
@@ -110,10 +110,9 @@ class HillClimberDiscovery(Discovery):
         :returns: The inferred causal DAG.
         """
 
-        start_time = time.time()
         individual = CausalDAG(ignore_cycles=True)
         individual.add_nodes_from(self.df.columns)
-        individual.add_edges_from(self.possible_edges, ignore_cycles=True)
+        individual.add_edges_from(self.possible_edges)
         self.remove_cycles(individual)
         fitness_values, problem_edges = self.evaluate_fitness(individual)
 
@@ -138,7 +137,7 @@ class HillClimberDiscovery(Discovery):
                     new_individual.remove_edge(origin, dest)
                 elif not new_individual.has_edge(origin, dest) and (origin, dest) not in self.exclude_edges:
                     # Want to bypass the cycle check of CausalDAG as we remove the cycles afterwards
-                    new_individual.add_edge(origin, dest, ignore_cycles=True)
+                    new_individual.add_edge(origin, dest)
             self.remove_cycles(new_individual)
             new_fitness_values, new_problem_edges = self.evaluate_fitness(new_individual)
 
@@ -149,9 +148,5 @@ class HillClimberDiscovery(Discovery):
                 iterations_without_improvement = 0
             else:
                 iterations_without_improvement += 1
-
-        end_time = time.time()
-        individual.graph["fitness"] = fitness_values
-        individual.graph["time"] = round(end_time - start_time)
 
         return individual

--- a/causal_testing/discovery/hill_climber_discovery.py
+++ b/causal_testing/discovery/hill_climber_discovery.py
@@ -111,9 +111,9 @@ class HillClimberDiscovery(Discovery):
         """
 
         start_time = time.time()
-        individual = CausalDAG()
+        individual = CausalDAG(ignore_cycles=True)
         individual.add_nodes_from(self.df.columns)
-        individual.add_edges_from(self.possible_edges)
+        individual.add_edges_from(self.possible_edges, ignore_cycles=True)
         self.remove_cycles(individual)
         fitness_values, problem_edges = self.evaluate_fitness(individual)
 

--- a/causal_testing/discovery/nsga_discovery.py
+++ b/causal_testing/discovery/nsga_discovery.py
@@ -42,10 +42,12 @@ class NSGADiscovery(Discovery):
         possible_edges[i] being an edge in the graph and 0 represents it not being.
         :returns: The converted CausalDAG instance.
         """
-        causal_dag = CausalDAG()
+        causal_dag = CausalDAG(ignore_cycles=True)
         origins, destinations = zip(*self.possible_edges)
         causal_dag.add_nodes_from(set(origins).union(set(destinations)))
-        causal_dag.add_edges_from([edge for edge, add in zip(self.possible_edges, individual) if add])
+        causal_dag.add_edges_from(
+            [edge for edge, add in zip(self.possible_edges, individual) if add], ignore_cycles=True
+        )
         return causal_dag
 
     def causal_dag_to_binary_string(self, causal_dag: CausalDAG) -> np.array:

--- a/causal_testing/discovery/nsga_discovery.py
+++ b/causal_testing/discovery/nsga_discovery.py
@@ -45,9 +45,7 @@ class NSGADiscovery(Discovery):
         causal_dag = CausalDAG(ignore_cycles=True)
         origins, destinations = zip(*self.possible_edges)
         causal_dag.add_nodes_from(set(origins).union(set(destinations)))
-        causal_dag.add_edges_from(
-            [edge for edge, add in zip(self.possible_edges, individual) if add], ignore_cycles=True
-        )
+        causal_dag.add_edges_from([edge for edge, add in zip(self.possible_edges, individual) if add])
         return causal_dag
 
     def causal_dag_to_binary_string(self, causal_dag: CausalDAG) -> np.array:

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -179,19 +179,36 @@ class CausalDAG(nx.DiGraph):
                 raise ValueError(f"Instrument {instrument} and outcome {outcome} share common causes")
         return True
 
-    def add_edge(self, u_of_edge: Node, v_of_edge: Node, ignore_cycles: bool = False, **attr):
-        """Add an edge to the causal DAG.
-
-        Overrides the default networkx method to prevent users from adding a cycle.
+    def add_edge(self, u_of_edge: Node, v_of_edge: Node, **attr):
+        """
+        Add an edge to the causal DAG.
+        Overrides the default networkx method to prevent users from inadvertently adding a cycle.
 
         :param u_of_edge: Origin node
         :param v_of_edge: Destination node
-        :param ignore_cycles: Whether to ignore cycles that adding the new edge may have introduced.
-        :param attr: Attributes
+        :param attr: Attributes passed to superclass method.
         """
         super().add_edge(u_of_edge, v_of_edge, **attr)
-        if not ignore_cycles and not self.is_acyclic():
-            raise nx.HasACycle("Invalid Causal DAG: contains a cycle.")
+        if not self.ignore_cycles and not self.is_acyclic():
+            raise nx.HasACycle(
+                "Invalid Causal DAG: contains a cycle. If this was intentional, set `dag.ignore_cycles` to true."
+            )
+
+    def add_edges_from(self, ebunch_to_add: list, **attr):
+        """
+        Add all the edges in ebunch_to_add.
+        Overrides the default networkx method to prevent users from inadvertently adding a cycle.
+
+        :param ebunch_to_add: container of edges. Each edge given in the container will be added to the graph.
+                              The edges must be given as 2-tuples (u, v) or 3-tuples (u, v, d) where d is a dictionary
+                              containing edge data.
+        :param attr: Attributes passed to superclass method.
+        """
+        super().add_edges_from(ebunch_to_add, **attr)
+        if not self.ignore_cycles and not self.is_acyclic():
+            raise nx.HasACycle(
+                "Invalid Causal DAG: contains a cycle. If this was intentional, set `dag.ignore_cycles` to true."
+            )
 
     def cycle_nodes(self) -> list:
         """Get the nodes involved in any cycles.

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -148,7 +148,10 @@ class CausalDAG(nx.DiGraph):
                     "Cycles found. Ignoring them can invalidate causal estimates. Proceed with extreme caution."
                 )
             else:
-                raise nx.HasACycle("Invalid Causal DAG: contains a cycle.")
+                raise nx.HasACycle(
+                    f"Invalid Causal DAG: contains a cycle {next(nx.simple_cycles(self))}. "
+                    "If this was intentional, set `dag.ignore_cycles` to true."
+                )
 
     def check_iv_assumptions(self, treatment, outcome, instrument) -> bool:
         """
@@ -191,7 +194,8 @@ class CausalDAG(nx.DiGraph):
         super().add_edge(u_of_edge, v_of_edge, **attr)
         if not self.ignore_cycles and not self.is_acyclic():
             raise nx.HasACycle(
-                "Invalid Causal DAG: contains a cycle. If this was intentional, set `dag.ignore_cycles` to true."
+                f"Invalid Causal DAG: contains a cycle {next(nx.simple_cycles(self))}. "
+                "If this was intentional, set `dag.ignore_cycles` to true."
             )
 
     def add_edges_from(self, ebunch_to_add: list, **attr):
@@ -207,7 +211,8 @@ class CausalDAG(nx.DiGraph):
         super().add_edges_from(ebunch_to_add, **attr)
         if not self.ignore_cycles and not self.is_acyclic():
             raise nx.HasACycle(
-                "Invalid Causal DAG: contains a cycle. If this was intentional, set `dag.ignore_cycles` to true."
+                f"Invalid Causal DAG: contains a cycle {next(nx.simple_cycles(self))}. "
+                "If this was intentional, set `dag.ignore_cycles` to true."
             )
 
     def cycle_nodes(self) -> list:

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -153,6 +153,23 @@ class CausalDAG(nx.DiGraph):
                     "If this was intentional, set `dag.ignore_cycles` to true."
                 )
 
+    def copy(self, as_view: bool = False) -> CausalDAG:
+        """
+        Returns a copy of the graph.
+        The copy method by default returns an independent shallow copy of the graph and attributes. That is, if an
+        attribute is a container, that container is shared by the original an the copy. Use Python’s copy.deepcopy for
+        new containers.
+        If as_view is True then a view is returned instead of a copy.
+
+        :param as_view: optional (default=False).
+                        If True, the returned graph-view provides a read-only view of the original graph without
+                        actually copying any data.
+        """
+        new_individual = super().copy(as_view=as_view)
+        new_individual.datatypes = self.datatypes
+        new_individual.ignore_cycles = self.ignore_cycles
+        return new_individual
+
     def check_iv_assumptions(self, treatment, outcome, instrument) -> bool:
         """
         Checks the three instrumental variable assumptions, raising a

--- a/causal_testing/specification/causal_dag.py
+++ b/causal_testing/specification/causal_dag.py
@@ -142,17 +142,6 @@ class CausalDAG(nx.DiGraph):
                 raise ValueError(f"Unsupported file extension {file_path}. We only support .dot and .xml files.")
             self.update(graph)
 
-        if not self.is_acyclic():
-            if ignore_cycles:
-                logger.warning(
-                    "Cycles found. Ignoring them can invalidate causal estimates. Proceed with extreme caution."
-                )
-            else:
-                raise nx.HasACycle(
-                    f"Invalid Causal DAG: contains a cycle {next(nx.simple_cycles(self))}. "
-                    "If this was intentional, set `dag.ignore_cycles` to true."
-                )
-
     def copy(self, as_view: bool = False) -> CausalDAG:
         """
         Returns a copy of the graph.

--- a/tests/discovery_tests/test_abstract_discovery.py
+++ b/tests/discovery_tests/test_abstract_discovery.py
@@ -6,6 +6,7 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 
+import networkx as nx
 import pandas as pd
 from numpy import nan
 
@@ -44,7 +45,7 @@ class TestAbstractHillClimber(unittest.TestCase):
         )
 
     def test_simple_cycle(self):
-        dag = CausalDAG()
+        dag = CausalDAG(ignore_cycles=True)
         dag.add_edges_from([("A", "B"), ("B", "C"), ("C", "A")])
         self.assertEqual(simple_cycle(dag), [("A", "B"), ("B", "C"), ("C", "A")])
 
@@ -101,7 +102,7 @@ class TestAbstractHillClimber(unittest.TestCase):
         self.assertEqual(abstract_discovery.include_edges, [(f"x_{n}", "y_1") for n in range(1, 4)])
 
     def test_include_edge_cycle(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(nx.exception.HasACycle):
             AbstractDiscovery(
                 df=pd.DataFrame(columns=["x_1", "x_2", "x_3", "y_1", "y_2", "y_3", "z_1", "z_2"]),
                 include_edges=[("x_1", "y_1"), ("y_1", "x_1")],
@@ -115,9 +116,9 @@ class TestAbstractHillClimber(unittest.TestCase):
         self.assertEqual(abstract_discovery.exclude_edges, [(f"x_{n}", "y_1") for n in range(1, 4)])
 
     def test_remove_cycles(self):
-        dag = CausalDAG()
+        dag = CausalDAG(ignore_cycles=True)
         dag.add_edges_from([("A", "B"), ("B", "C")])
-        dag.add_edge("C", "A", ignore_cycles=True)
+        dag.add_edge("C", "A")
         self.assertFalse(dag.is_acyclic(), "A -> B -> C -> A should form a cycle.")
 
         abstract_discovery = AbstractDiscovery(pd.DataFrame())
@@ -125,9 +126,9 @@ class TestAbstractHillClimber(unittest.TestCase):
         self.assertTrue(dag.is_acyclic())
 
     def test_remove_cycles_respects_include_edges(self):
-        dag = CausalDAG()
+        dag = CausalDAG(ignore_cycles=True)
         dag.add_edges_from([("A", "B"), ("B", "C")])
-        dag.add_edge("C", "A", ignore_cycles=True)
+        dag.add_edge("C", "A")
 
         include_edges = {("A", "B"), ("B", "C")}
         abstract_discovery = AbstractDiscovery(pd.DataFrame(columns=dag.nodes), include_edges=include_edges)
@@ -146,7 +147,7 @@ class TestAbstractHillClimber(unittest.TestCase):
         self.assertEqual(len(dag.edges()), 1)
 
     def test_remove_cycles_multiple_cycles(self):
-        dag = CausalDAG()
+        dag = CausalDAG(ignore_cycles=True)
         dag.add_edges_from([("A", "B"), ("C", "D"), ("B", "A"), ("D", "C")])
 
         abstract_discovery = AbstractDiscovery(pd.DataFrame())

--- a/tests/discovery_tests/test_hill_climber_discovery.py
+++ b/tests/discovery_tests/test_hill_climber_discovery.py
@@ -109,7 +109,7 @@ class TestHillClimber(unittest.TestCase):
 
         hill_climber = HillClimberDiscovery(scarf_df)
         fitness_values, problem_edges = hill_climber.evaluate_fitness(dag)
-        expected_fitness_values = (4, -2, 0)
+        expected_fitness_values = (4 / 6, -2 / 6, 0)
         expected_problem_edges = [
             ("length_in", "completed"),
             ("large_gauge", "completed"),

--- a/tests/discovery_tests/test_hill_climber_discovery.py
+++ b/tests/discovery_tests/test_hill_climber_discovery.py
@@ -124,7 +124,7 @@ class TestHillClimber(unittest.TestCase):
             scarf_df,
             include_edges=[("length_in", "completed")],
             exclude_edges=[("color", "length_in")],
-            max_iterations=10,
+            max_iterations=20,
         )
         dag = hill_climber.discover()
         self.assertTrue(

--- a/tests/discovery_tests/test_nsga_discovery.py
+++ b/tests/discovery_tests/test_nsga_discovery.py
@@ -45,7 +45,7 @@ class TestNSGA(unittest.TestCase):
             scarf_df,
             include_edges=[("length_in", "completed")],
             exclude_edges=[("color", "length_in")],
-            max_iterations=10,
+            max_iterations=20,
         )
         dag = hill_climber.discover()
         self.assertTrue(

--- a/tests/discovery_tests/test_nsga_discovery.py
+++ b/tests/discovery_tests/test_nsga_discovery.py
@@ -21,9 +21,10 @@ class TestNSGA(unittest.TestCase):
         dag.add_edges_from([("length_in", "completed"), ("large_gauge", "completed")])
         nsga = NSGADiscovery(scarf_df)
 
-        self.assertTrue(
-            nx.utils.graphs_equal(dag, nsga.binary_string_to_causal_dag(nsga.causal_dag_to_binary_string(dag)))
-        )
+        back_translated_dag = nsga.binary_string_to_causal_dag(nsga.causal_dag_to_binary_string(dag))
+
+        self.assertEqual(dag.nodes, back_translated_dag.nodes)
+        self.assertEqual(dag.edges, back_translated_dag.edges)
 
     def test_multiobjective_fitness(self):
         scarf_df = pd.read_csv("tests/resources/data/scarf_data.csv")

--- a/tests/specification_tests/test_causal_dag.py
+++ b/tests/specification_tests/test_causal_dag.py
@@ -88,9 +88,12 @@ class TestCausalDAG(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dag_dot_path = os.path.join(self.temp_dir_path, "dag.dot")
-        dag_dot = """digraph G { A -> B; B -> C; D -> A; D -> C;}"""
         f = open(self.dag_dot_path, "w")
-        f.write(dag_dot)
+        f.write("digraph G { A -> B; B -> C; D -> A; D -> C;}")
+
+        self.dcg_dot_path = os.path.join(self.temp_dir_path, "dcg.dot")
+        f = open(self.dcg_dot_path, "w")
+        f.write("digraph G { A -> B; B -> A; }")
         f.close()
 
     def test_valid_causal_dag(self):
@@ -103,10 +106,14 @@ class TestCausalDAG(unittest.TestCase):
             ("D", "C"),
         ]
 
-    def test_invalid_causal_dag(self):
-        """Test whether a cycle-containing directed graph is an invalid causal DAG."""
+    def test_add_cycle(self):
+        """Test that adding an edge that introduces a cycle raises an error."""
         causal_dag = CausalDAG(self.dag_dot_path)
         self.assertRaises(nx.HasACycle, causal_dag.add_edge, "C", "A")
+
+    def test_read_cycle(self):
+        """Test that reading a graph that has a cycle raises an error."""
+        self.assertRaises(nx.HasACycle, CausalDAG, self.dcg_dot_path)
 
     def test_empty_casual_dag(self):
         """Test whether an empty dag can be created."""


### PR DESCRIPTION
# Main changes
`hill_climber_discovery.py`
- Normalising fitness by number of generated tests
- Using a `for` loop for generational process instead of a `while`

'causal_dag.py`
- Override `add_edges_from` to include a check for cycles
- Removed resulting dead code cycle check from constructor

`__main__.py`
Outputting raw discovered DAG rather than a pretty rendering of passing/failing test results.

Tests for the above.